### PR TITLE
Set "overflow: auto" CSS property on "pre" elements for standalone HTMLs

### DIFF
--- a/t/custom-templates/css.tt
+++ b/t/custom-templates/css.tt
@@ -71,6 +71,11 @@ div#page {
 pre, code {
     font-family: Consolas, courier, monospace;
 }
+
+pre {
+    overflow: auto;
+}
+
 /* invisibles */
 span.hiddenindex, span.commentmarker, .comment, span.tocprefix, #hitme {
     display: none


### PR DESCRIPTION
Otherwise the whole page of, for example, markup manual, is scrolled horizontally on mobile devices