### PR TITLE
Remove "fw" class or replace it with "fa-fw" as needed

### DIFF
--- a/root/src/attachments/list.tt
+++ b/root/src/attachments/list.tt
@@ -49,7 +49,7 @@
       </td>
       <td>
         <a href="[% c.uri_for_action('/attachments/edit', [ att.name ]) %]">
-          <span class="fa fa-edit fa-2x fa-border fw" aria-hidden="true"></span>
+          <span class="fa fa-edit fa-2x fa-border" aria-hidden="true"></span>
         </a>
       </td>
     </tr>

--- a/root/src/include/preamble.tt
+++ b/root/src/include/preamble.tt
@@ -123,7 +123,7 @@
         <span id="download-format-[% cformat.code %]">
           <a href="[% c.uri_for(text.full_uri) %][% cformat.ext %]" class="amw-register-stat"
              data-amw-register-stat-type="[% cformat.code %]">
-            <span class="fa [% cformat.icon %] fa-2x fa-border fw"
+            <span class="fa [% cformat.icon %] fa-2x fa-border"
                   aria-hidden="true"
                   title="[% loc(cformat.desc) %]"
                   data-toggle="tooltip" data-placement="top"
@@ -136,7 +136,7 @@
         [% IF site.cgit_integration || c.user_exists %]
       <span id="filehistory">
         <a href="[% c.uri_for(cgit_link, { showmsg => 1 }) %]" rel="nofollow">
-          <span class="fa fa-history fa-2x fa-border fw"
+          <span class="fa fa-history fa-2x fa-border"
                 aria-hidden="true"
                 title="[% loc('View history') %]"
                 data-toggle="tooltip" data-placement="top"
@@ -147,7 +147,7 @@
       [% IF c.user_exists || site.human_can_edit %]
       <span id="text-edit-button">
         <a href="[% c.uri_for(text.full_edit_uri) %]">
-          <span class="fa fa-edit fa-2x fa-border fw"
+          <span class="fa fa-edit fa-2x fa-border"
                 aria-hidden="true"
                 title="[% loc('Edit this text') %]"
                 data-toggle="tooltip" data-placement="top"
@@ -159,7 +159,7 @@
            id="add-to-bookbuilder"
            class="amw-register-stat"
            data-amw-register-stat-type="bookbuilder">
-          <span class="fa fa-book fa-2x fa-border fw"
+          <span class="fa fa-book fa-2x fa-border"
                 aria-hidden="true"
                 title="[% loc('Add this text to the bookbuilder') %]"
                 data-toggle="tooltip" data-placement="top"
@@ -170,7 +170,7 @@
            class="amw-register-stat"
            id="add-to-bookbuilder-partial"
            data-amw-register-stat-type="bookbuilder">
-          <span class="fa fa-list-alt fa-2x fa-border fw"
+          <span class="fa fa-list-alt fa-2x fa-border"
                 aria-hidden="true"
                 title="[% loc('Select individual parts for the bookbuilder') %]"
                 data-toggle="tooltip" data-placement="top"
@@ -179,7 +179,7 @@
       [% IF c.user_exists %]
       <span id="create-rebuild-job">
         <a href="[% c.uri_for(text.full_rebuild_uri) %]">
-          <span class="fa fa-refresh fa-2x fa-border fw"
+          <span class="fa fa-refresh fa-2x fa-border"
                 aria-hidden="true"
                 data-toggle="tooltip" data-placement="top"
                 title="[% loc('Rebuild the generated formats') %]"></span><span class="sr-only" >
@@ -193,7 +193,7 @@
            data-toggle="modal"
            title="[% loc('What links here') %]"
            data-target="#backlinks-modal">
-          <span class="fa fa-link fa-2x fa-border fw"></span>
+          <span class="fa fa-link fa-2x fa-border"></span>
         </a>
       </span>
       [% END %]

--- a/root/src/layout.tt
+++ b/root/src/layout.tt
@@ -196,7 +196,7 @@
                 <div class="input-group-btn">
                   <button type="submit" class="btn btn-primary">
                     <span class="sr-only">[% loc('Search') %]</span>
-                    <span class="fa fa-search fw"></span>
+                    <span class="fa fa-search fa-fw"></span>
                   </button>
                 </div>
               </div>
@@ -208,7 +208,7 @@
                  data-toggle="modal"
                  title="[% loc('Table of Contents') %]"
                  data-target="#myModal">
-                <span class="fa fa-list text-primary fw"></span>
+                <span class="fa fa-list text-primary fa-fw"></span>
                 <span class=" visible-xs-inline">
                   [% loc('Table of Contents') %]
                 </span>
@@ -218,7 +218,7 @@
               <a href="#" class="dropdown-toggle"
                  title="[% loc('texts by authors, title, topic...') %]"
                  data-toggle="dropdown">
-                <span class="fa fa-heart fw"></span>
+                <span class="fa fa-heart fa-fw"></span>
                 <span class="hidden-sm" id="amw-catalog-label">
                   [% loc('Archive') %]
                 </span>
@@ -314,7 +314,7 @@
               <a href="#" class="dropdown-toggle"
                  title="[% loc('about, links...') %]"
                  data-toggle="dropdown">
-                <span class="fa fa-ellipsis-h fw"></span>
+                <span class="fa fa-ellipsis-h fa-fw"></span>
                 <span class="visible-lg-inline visible-xs-inline" id="awm-special-label">
                   [% loc('More') %]
                 </span>
@@ -336,7 +336,7 @@
               <a href="#" class="dropdown-toggle"
                  title="[% loc('Related projects') %]"
                  data-toggle="dropdown">
-                <span class="fa fa-th fw"></span>
+                <span class="fa fa-th fa-fw"></span>
                 <span class="hidden-sm" id="amw-sitegroup-label">
                   [% loc('Related projects') %]
                 </span>
@@ -359,7 +359,7 @@
               <a href="#" class="dropdown-toggle"
                  title="[% loc('Language selection') %]"
                  data-toggle="dropdown">
-                <span class="fa fa-globe fw"></span>
+                <span class="fa fa-globe fa-fw"></span>
                 <span class="visible-xs-inline">
                   [% loc('Language selection') %]
                 </span>
@@ -387,7 +387,7 @@
                  class="dropdown-toggle"
                  title="[% c.user.get('username') | html %]"
                  data-toggle="dropdown">
-                <span class="fa fa-user fw"></span>
+                <span class="fa fa-user fa-fw"></span>
                 <span class="visible-xs-inline">
                   [% c.user.get('username') | html %]
                 </span>
@@ -523,7 +523,7 @@
             <li [% IF nav == 'bookbuilder' %] class="active" [% END %]>
               <a href="[% c.uri_for('/bookbuilder') %]" title="[% loc('Bookbuilder') %]">
                 [% SET bb_count_texts = c.model('BookBuilder').total_texts %]
-                <span class="fa fa-book [% IF bb_count_texts %]text-primary[% END %] fw"></span>
+                <span class="fa fa-book [% IF bb_count_texts %]text-primary[% END %] fa-fw"></span>
                 <span class="visible-lg-inline visible-xs-inline">
                   [% loc('Bookbuilder') %]
                 </span>
@@ -534,7 +534,7 @@
             </li>
             <li id="amw-navbar-opds-link">
               <a href="[% c.uri_for('/help/opds') %]" title="[% loc('Mobile') %]">
-                <span class="fa fa-tablet fw"></span>
+                <span class="fa fa-tablet fa-fw"></span>
                 <span class="visible-xs-inline">
                   [% loc('Mobile applications') %]
                 </span>
@@ -542,7 +542,7 @@
             </li>
             <li id="amw-navbar-feed-link">
               <a href="[% c.uri_for('/feed') %]" title="[% loc('RSS feed') %]">
-                <span class="fa fa-rss fw"></span>
+                <span class="fa fa-rss fa-fw"></span>
                 <span class="visible-xs-inline">
                   [% loc('RSS feed') %]
                 </span>
@@ -550,7 +550,7 @@
             </li>
             <li id="amw-navbar-opds-random">
               <a href="[% c.uri_for('/random') %]" title="[% loc('Random') %]">
-                <span class="fa fa-random fw"></span>
+                <span class="fa fa-random fa-fw"></span>
                 <span class="visible-xs-inline">
                   [% loc('Random') %]
                 </span>
@@ -559,7 +559,7 @@
             [% IF c.user_exists || site.human_can_edit %]
             <li id="awm-navbar-add-new-text-icon">
               <a href="[% c.uri_for_action('/edit/newtext', ['text']) %]" title="[% loc('Add a new text') %]">
-                <span class="fa fa-plus fw"></span>
+                <span class="fa fa-plus fa-fw"></span>
                 <span class="visible-xs-inline">
                   [% loc('Add a new text') %]
                 </span>
@@ -617,7 +617,7 @@
       [% END %]
       [% IF c.flash.error_msg %]
       <div class="alert alert-warning" id="error_message">
-        <span class="fa fa-exclamation-triangle fw"></span>
+        <span class="fa fa-exclamation-triangle"></span>
         [% c.flash.error_msg | html %]
       </div>
       [% END %]

--- a/root/src/static-indexes.tt
+++ b/root/src/static-indexes.tt
@@ -175,7 +175,7 @@
           <div class="col-xs-5">
             [%- FOREACH format IN formats %]
             [%- IF format.is_slides && !text.slides %]
-            <span class="fa fa-2x fa-border fa-ban fw"
+            <span class="fa fa-2x fa-border fa-ban"
                   title="[% format.desc %] [% lh.loc('N/A') %]"
                   aria-hidden="true"
                   data-toggle="tooltip"
@@ -183,7 +183,7 @@
             </span><span class="sr-only">[% format.desc %] [% lh.loc('N/A') %]</span>
             [%- ELSE %]
             <a class="force-black" href="[% text.in_tree_uri %][% format.ext %]">
-              <span class="fa fa-2x fa-border [% format.icon %] fw"
+              <span class="fa fa-2x fa-border [% format.icon %]"
                     title="[% format.desc %]"
                     aria-hidden="true"
                     data-toggle="tooltip"

--- a/root/src/tasks/show_bulk_job.tt
+++ b/root/src/tasks/show_bulk_job.tt
@@ -54,22 +54,22 @@ function update_bulk_status() {
             var icon = $('<span>');
             if (item.status == 'pending') {
                 if (spin_first) {
-                    icon.attr("class", "fa fa-clock-o fa-spin fa-2x fw");
+                    icon.attr("class", "fa fa-clock-o fa-spin fa-2x");
                     spin_first = 0;
                 }
                 else {
-                    icon.attr("class", "fa fa-clock-o fa-2x fw");
+                    icon.attr("class", "fa fa-clock-o fa-2x");
                 }
             }
             else if (item.status == 'failed') {
-                icon.attr("class", "fa fa-exclamation-circle fa-2x fw text-danger");
+                icon.attr("class", "fa fa-exclamation-circle fa-2x text-danger");
             }
             else if (item.status == 'taken') {
-                icon.attr("class", "fa fa-cog fa-spin fa-2x fw");
+                icon.attr("class", "fa fa-cog fa-spin fa-2x");
                 spin_first = 0;
             }
             else if (item.status == 'completed') {
-                icon.attr("class", "fa fa-check-circle-o fa-2x fw text-success");
+                icon.attr("class", "fa fa-check-circle-o fa-2x text-success");
             }
             table.append($('<tr>').append(
                 $('<td>').css('text-align', 'center')


### PR DESCRIPTION
"Fixed width" class for Font Awesome icons is called "fa-fw", not "fw". In most cases it was not necessary or even harmful.

In the navigation bar "fw" is replaced with "fa-fw" to make icons fixed-width. It is important in "mobile" (small width) layout, where icons are stacked vertically, to make the list items align.