### PR TITLE
Font installation script improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,9 @@ Vagrant.configure("2") do |config|
 
     sudo apt-get install --no-install-recommends --no-install-suggests -y \
       texlive-base                                                        \
-      texlive-generic-recommended texlive-fonts-recommended               \
+      texlive-fonts-extra                                                 \
+      texlive-fonts-recommended                                           \
+      texlive-generic-recommended                                         \
       texlive-lang-all                                                    \
       texlive-latex-base                                                  \
       texlive-latex-extra                                                 \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure("2") do |config|
 
   # Install dependencies
   config.vm.provision "apt", type: "shell", privileged: false, inline: <<-SHELL
+    set -e
+
     sudo apt-get update
     sudo apt-get install -y nginx
 
@@ -101,6 +103,8 @@ Vagrant.configure("2") do |config|
 
   # Configure Amusewiki
   config.vm.provision "amusewiki-configure", type: "shell", privileged: false, inline: <<-SHELL
+    set -e
+
     cd /vagrant
 
     eval `perl -Mlocal::lib`
@@ -118,6 +122,8 @@ Vagrant.configure("2") do |config|
 
   # Start Amusewiki services on every "vagrant up" or "vagrant reload"
   config.vm.provision "amusewiki-run", type: "shell", privileged: false, run: "always", inline: <<-SHELL
+    set -e
+
     cd /vagrant
     eval `perl -Mlocal::lib`
     script/jobber.pl start

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,6 +91,9 @@ Vagrant.configure("2") do |config|
     # Required by /vagrant/script/upgrade_i18n
     sudo apt-get install --no-install-recommends --no-install-suggests -y gettext
 
+    # Required by cgit
+    sudo apt-get install --no-install-recommends --no-install-suggests -y libssl-dev
+
     # Install local::lib
     sudo apt-get install -y liblocal-lib-perl
     echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)"' >>~/.bashrc

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,6 +82,10 @@ Vagrant.configure("2") do |config|
       texlive-luatex                                                      \
       texlive-xetex                                                       \
 
+    sudo apt-get install --no-install-recommends --no-install-suggests -y \
+      fonts-cmu \
+      fonts-texgyre
+
     # Required by /vagrant/script/upgrade_i18n
     sudo apt install --no-install-recommends --no-install-suggests -y gettext
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,7 @@ Vagrant.configure("2") do |config|
       fonts-texgyre
 
     # Required by /vagrant/script/upgrade_i18n
-    sudo apt install --no-install-recommends --no-install-suggests -y gettext
+    sudo apt-get install --no-install-recommends --no-install-suggests -y gettext
 
     # Install local::lib
     sudo apt-get install -y liblocal-lib-perl

--- a/script/install_fonts.sh
+++ b/script/install_fonts.sh
@@ -85,5 +85,11 @@ for font in 'CMU Serif'            \
                 ;;
         esac
         fc-cache -f
+
+        # Check that font is installed successfully
+        if ! fc-list "$font" | grep -q style; then
+            echo "Failed to install $font"
+            exit 3;
+        fi
     fi
 done

--- a/script/install_fonts.sh
+++ b/script/install_fonts.sh
@@ -4,32 +4,22 @@ set -e
 
 echo "Checking and installing missing fonts"
 
-texfontsdir=$HOME/texlive/2017/texmf-dist/fonts
-
-if [ ! -d $texfontsdir ]; then
-    texfontsdir=$HOME/texlive/2016/texmf-dist/fonts
-fi
-if [ ! -d $texfontsdir ]; then
-    texfontsdir=$HOME/texlive/2015/texmf-dist/fonts
-fi
-if [ ! -d $texfontsdir ]; then
-    texfontsdir=$HOME/texlive/2014/texmf-dist/fonts
-fi
-# freebsd
-if [ ! -d $texfontsdir ]; then
-    texfontsdir=/usr/local/share/texmf-dist/fonts
-fi
-# debian, but they move stuff around
-
-if [ ! -d $texfontsdir ]; then
-    texfontsdir=/usr/share/texmf/fonts
-fi
-
-
-if [ ! -d $texfontsdir ]; then
-    echo "Couldn't find $texfontsdir";
-    exit 2;
-fi
+linkfont () {
+    rm -fv `basename $1`
+    for texfontsdir in "$HOME/texlive/2017/texmf-dist/fonts" \
+                       "$HOME/texlive/2016/texmf-dist/fonts" \
+                       "$HOME/texlive/2015/texmf-dist/fonts" \
+                       "$HOME/texlive/2014/texmf-dist/fonts" \
+                       "/usr/local/share/texmf-dist/fonts" \
+                       "/usr/share/texmf/fonts" \
+                       "/usr/share/texlive/texmf-dist/fonts"; do
+        if [ -d "$texfontsdir/$1" ]; then
+            ln -s "$texfontsdir/$1"
+            return 0
+        fi
+    done
+    return 0
+}
 
 mkdir -p $HOME/.fonts
 cd $HOME/.fonts
@@ -59,42 +49,31 @@ for font in 'CMU Serif'            \
         echo "$font NOT installed, installing"
         case "$font" in
             Linux*)
-                rm -fv libertine
-                ln -s $texfontsdir/opentype/public/libertine
+                linkfont opentype/public/libertine
                 ;;
             TeX*)
-                rm -fv tex-gyre
-                ln -s $texfontsdir/opentype/public/tex-gyre
+                linkfont opentype/public/tex-gyre
                 ;;
             CMU*)
-                rm -fv cm-unicode
-                ln -s $texfontsdir/opentype/public/cm-unicode
+                linkfont opentype/public/cm-unicode
                 ;;
             *Torunska*)
-                rm -fv antt
-                ln -s $texfontsdir/opentype/public/antt
+                linkfont opentype/public/antt
                 ;;
             *Poltawskiego*)
-                rm -fv poltawski
-                ln -s $texfontsdir/opentype/gust/poltawski
+                linkfont opentype/gust/poltawski
                 ;;
             PT*)
-                rm -fv paratype
-                ln -s $texfontsdir/truetype/paratype
+                linkfont truetype/paratype
                 ;;
             Iwona*)
-                rm -fv iwona
-                ln -s $texfontsdir/opentype/nowacki/iwona
+                linkfont opentype/nowacki/iwona
                 ;;
             Noto*)
-                rm -fv noto
-                if [ -d $texfontsdir/truetype/google/noto ]; then
-                    ln -s $texfontsdir/truetype/google/noto
-                fi
+                linkfont truetype/google/noto
                 ;;
             DejaVu*)
-                rm -fv dejavu
-                ln -s $texfontsdir/truetype/public/dejavu
+                linkfont $texfontsdir/truetype/public/dejavu
                 ;;
             *Charis*)
                 rm -fv charis


### PR DESCRIPTION
In this PR I made all installation scripts finish without errors. Some (5 of them) tests are still failing on `make test`.

The main thing to review is `install_fonts.sh` changes. I made it check that the font is actually available after symlinking it, because before it just happily created symlinks to nonexistent directories.