### PR TITLE
Make script/upgrade_i18n output stable

### DIFF
--- a/lib/AmuseWikiFarm/I18N/ar.po
+++ b/lib/AmuseWikiFarm/I18N/ar.po
@@ -135,8 +135,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -289,6 +289,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -329,8 +335,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -783,6 +789,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -866,14 +875,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -982,8 +991,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1376,8 +1385,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1984,6 +1993,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2156,6 +2168,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2283,8 +2298,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2642,12 +2657,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/cs.po
+++ b/lib/AmuseWikiFarm/I18N/cs.po
@@ -136,8 +136,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -290,6 +290,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -330,8 +336,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -784,6 +790,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -867,14 +876,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -983,8 +992,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1377,8 +1386,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1985,6 +1994,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2157,6 +2169,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2284,8 +2299,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2643,12 +2658,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/da.po
+++ b/lib/AmuseWikiFarm/I18N/da.po
@@ -148,8 +148,8 @@ msgstr ""
 "Yderligere information (hele datoen, originaltitel, oversættere, "
 "bidragydere, etc.)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -317,6 +317,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -357,8 +363,8 @@ msgid "Changes applied"
 msgstr "Ændringer udført"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Ændringer for %1"
 
@@ -836,6 +842,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML til at indsætte i den venstre sidebar"
 
@@ -929,14 +938,14 @@ msgstr "IRC kanal på freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -1073,8 +1082,8 @@ msgstr ""
 "I teksten fortolkes et tal i klammer som en\n"
 "          fodnotehenvisning, hvis en sådan fodnote findes."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1489,8 +1498,8 @@ msgstr "PDF logo"
 msgid "PDFs cannot be used in the body."
 msgstr "PDF'er kan ikke bruges i brødteksten."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 "PDF'er som ikke er fortegnet i %1 direktivet bliver opbevaret men ignoreret."
@@ -2152,6 +2161,9 @@ msgstr "Statisk side uden javaskript"
 msgid "Status"
 msgstr "Status"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Undersektion"
 
@@ -2325,6 +2337,9 @@ msgstr "Hent derefter opdateringerne på denne side."
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Disse tekster mangler den unikke ID."
 
@@ -2463,8 +2478,8 @@ msgstr "For at hurtigt formatere skuespil, anvend"
 msgid "To resume the editing you can visit the following URL"
 msgstr "For at genoptage redigeringen kan du besøge den følgende URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2857,12 +2872,6 @@ msgstr "enhver"
 msgid "automatically generated if not present, using author and title"
 msgstr ""
 "bliver automatisk genereret hvis feltet er tomt, bruger forfatter og titel"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "kode og monospatieret"

--- a/lib/AmuseWikiFarm/I18N/de.po
+++ b/lib/AmuseWikiFarm/I18N/de.po
@@ -144,8 +144,8 @@ msgstr ""
 "Zusätzliche Informationen (vollständiges Datum, Originaltitel, "
 "ÜbersetzerIn, , etc)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -304,6 +304,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -344,8 +350,8 @@ msgid "Changes applied"
 msgstr "Änderungen angewandt"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Änderungen für %1"
 
@@ -803,6 +809,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -886,14 +895,14 @@ msgstr ""
 msgid "Id"
 msgstr "ID"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -1011,8 +1020,8 @@ msgstr ""
 " als Fußnotenreferenz interpretiert, wenn eine solche\n"
 " Fußnote existiert.  "
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1421,8 +1430,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr "PDFs können im Textkörper nicht verwendet werden."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 "Nicht in der %1 Anweisung aufgelistete PDFs werden gespeichert aber "
@@ -2055,6 +2064,9 @@ msgstr ""
 msgid "Status"
 msgstr "Status"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Untersektion"
 
@@ -2236,6 +2248,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Diesen Texten fehlt die einzigartige ID."
 
@@ -2370,8 +2385,8 @@ msgstr "Um Stücke schnell zu formatieren verwende"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Um die Bearbeitung wieder aufzunehmen besuche die folgende URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2746,12 +2761,6 @@ msgstr ""
 msgid "automatically generated if not present, using author and title"
 msgstr ""
 "automatisch erstellt falls nicht vorhanden, verwendet Autorin und Titel"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "Code und Monospace"

--- a/lib/AmuseWikiFarm/I18N/en.po
+++ b/lib/AmuseWikiFarm/I18N/en.po
@@ -136,8 +136,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -290,6 +290,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -330,8 +336,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -784,6 +790,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -867,14 +876,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -983,8 +992,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1377,8 +1386,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1985,6 +1994,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2157,6 +2169,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2284,8 +2299,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2643,12 +2658,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/es.po
+++ b/lib/AmuseWikiFarm/I18N/es.po
@@ -148,8 +148,8 @@ msgid ""
 msgstr ""
 "Información adicional (fecha, título original, traductores, créditos, etc.)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -323,6 +323,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -363,8 +369,8 @@ msgid "Changes applied"
 msgstr "Cambios aplicados"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Cambios para %1"
 
@@ -857,6 +863,9 @@ msgstr ""
 "            palabra, por lo que tienes la posibilidad de echar todo a\n"
 "            perder ahora, así que sé cuidadosa/o"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML a insertar en la barra lateral izquierda"
 
@@ -951,14 +960,14 @@ msgstr "Canal IRC en freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Si no se ajusta %1 será tomado desde el directorio de la aplicación."
 
@@ -1098,8 +1107,8 @@ msgstr ""
 "          referencia a una nota a pie de página, si es que dicha nota a pie "
 "de página existe."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1515,8 +1524,8 @@ msgstr "Logo PDF"
 msgid "PDFs cannot be used in the body."
 msgstr "No se pueden usar PDFs en el cuerpo."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 "Los PDFs no listados en la directiva %1 serán guardados, pero ignorados"
@@ -2185,6 +2194,9 @@ msgstr "Página estática sin javascript"
 msgid "Status"
 msgstr "Estado"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Subsección"
 
@@ -2380,6 +2392,9 @@ msgstr "Luego toma las actualizaciones desde esta página."
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Estos textos no tienen el id único."
 
@@ -2521,8 +2536,8 @@ msgstr "Para dar formato a diálogos, usa"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Para continuar editando, puedes visitar la siguiente URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2928,12 +2943,6 @@ msgstr "cualquiera"
 
 msgid "automatically generated if not present, using author and title"
 msgstr "generado automáticamente si no se ocupa, usando autor/a y título"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "código y mono espaciado"

--- a/lib/AmuseWikiFarm/I18N/fa.po
+++ b/lib/AmuseWikiFarm/I18N/fa.po
@@ -135,8 +135,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -289,6 +289,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -329,8 +335,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -783,6 +789,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -866,14 +875,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -982,8 +991,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1376,8 +1385,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1984,6 +1993,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2156,6 +2168,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2283,8 +2298,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2642,12 +2657,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/fi.po
+++ b/lib/AmuseWikiFarm/I18N/fi.po
@@ -140,8 +140,8 @@ msgid ""
 "etc)."
 msgstr "Lisätietoja (päivämäärä, alkuperäinen otsikko, kääntäjät jne.)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -299,6 +299,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -339,8 +345,8 @@ msgid "Changes applied"
 msgstr "Tehdyt muutokset"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Tekstin %1 muutokset"
 
@@ -796,6 +802,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -879,14 +888,14 @@ msgstr ""
 msgid "Id"
 msgstr "Tunniste"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -997,8 +1006,8 @@ msgstr ""
 "Tekstin sisällä hakasulkeissa oleva numero tulkitaan\n"
 "         loppuviitteeksi, mikäli lopussa on vastaava viite."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1408,8 +1417,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -2042,6 +2051,9 @@ msgstr "Staattinen sivu ilman javascriptiä"
 msgid "Status"
 msgstr "Tila"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Alaosio"
 
@@ -2218,6 +2230,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Näistä teksteistä puuttuu yksilöivä tunniste."
 
@@ -2349,8 +2364,8 @@ msgstr "Näytelmät saa muotoiltua nopeasti laittamalla ympärille tagit"
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2721,12 +2736,6 @@ msgstr ""
 
 msgid "automatically generated if not present, using author and title"
 msgstr "luodaan automaattisesti kirjoittajan ja otsikon pohjalta"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "koodi ja tasavälinen teksti"

--- a/lib/AmuseWikiFarm/I18N/fr.po
+++ b/lib/AmuseWikiFarm/I18N/fr.po
@@ -150,8 +150,8 @@ msgstr ""
 "Informations supplémentaires (date complète, titre original, traducteur/"
 "trice/s, crédits, etc)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -319,6 +319,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -359,8 +365,8 @@ msgid "Changes applied"
 msgstr "Modifications appliquées"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Modifications pour %1"
 
@@ -853,6 +859,9 @@ msgstr ""
 "HTML à ajouter à chaque page spéciale, inséré tel quel ; vous risquez de "
 "tout bousiller, donc soyez prudent·e"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML à insérer dans la barre verticale de gauche"
 
@@ -946,14 +955,14 @@ msgstr "Canal IRC sur freenode"
 msgid "Id"
 msgstr "ID"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Si non définit %1 sera cherché dans le répertoire d'applications."
 
@@ -1098,8 +1107,8 @@ msgstr ""
 "Dans le texte, un nombre entre crochets est interprété comme une référence "
 "de note de bas de page, si une telle note existe."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1517,8 +1526,8 @@ msgstr "Logo PDF"
 msgid "PDFs cannot be used in the body."
 msgstr "Les PDFs ne peuvent pas être utilisés dans le corps de texte."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 "Les PDFs non répertoriés dans la directive %1 seront stockés mais ignorés."
@@ -2188,6 +2197,9 @@ msgstr "Page statique sans javascript"
 msgid "Status"
 msgstr "Statut"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Sous-section"
 
@@ -2382,6 +2394,9 @@ msgstr "Puis aller chercher les mises à jour depuis cette page."
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Il manque l'ID unique de ces textes."
 
@@ -2527,8 +2542,8 @@ msgstr "Pour formater rapidement les pièces de théâtre, utilisez"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Pour reprendre l'édition vous pouvez visiter l'URL suivant"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2947,12 +2962,6 @@ msgid "automatically generated if not present, using author and title"
 msgstr ""
 "si non défini, il est automatiquement généré à partir de l'auteur·e et du "
 "titre"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "code et caractères à espacement fixe"

--- a/lib/AmuseWikiFarm/I18N/he.po
+++ b/lib/AmuseWikiFarm/I18N/he.po
@@ -136,8 +136,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -290,6 +290,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -330,8 +336,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -784,6 +790,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -867,14 +876,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -983,8 +992,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1377,8 +1386,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1985,6 +1994,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2157,6 +2169,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2284,8 +2299,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2643,12 +2658,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/hr.po
+++ b/lib/AmuseWikiFarm/I18N/hr.po
@@ -145,8 +145,8 @@ msgid ""
 msgstr ""
 "Dodatne informacije (kompletan datum, naslov originala, prevoditelji, itd.)"
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -312,6 +312,12 @@ msgstr ""
 "Druga vrsta fusnota koristi brojeve u zagradama npr. (1) kao oznake. Ovom će "
 "se opcijom koristiti slova, počevši iznova na svakoj stranici."
 
+msgid "By number of pages, ascending"
+msgstr "Po broju stranica (manje na početku)"
+
+msgid "By number of pages, descending"
+msgstr "Po broju stranica (više na početku)"
+
 msgid "By relevance"
 msgstr "Po relevantnosti"
 
@@ -352,8 +358,8 @@ msgid "Changes applied"
 msgstr "Unesene izmjene"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Izmjene za %1"
 
@@ -833,6 +839,9 @@ msgstr ""
 "Dodaj sljedeći HTML svakoj posebnoj stranici (/special/*), bez\n"
 "ikakve promjene (pazi što radiš)."
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML za lijevu stranu svake stranice"
 
@@ -922,14 +931,14 @@ msgstr "IRC kanal na mreži Freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Ako je prazno, koristit će se %1 iz direktorija aplikacije."
 
@@ -1070,8 +1079,8 @@ msgstr ""
 "U tekstu se broj unutar uglatih zagrada interpretira kao fusnota, ako "
 "fusnota postoji"
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1489,8 +1498,8 @@ msgstr "PDF logo"
 msgid "PDFs cannot be used in the body."
 msgstr "Nije moguće koristi PDF-ove unutar tekstova."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr "PDF-ovi koji nisu na popisu %1 polja bit će pohranjeni ali zanemareni."
 
@@ -2146,6 +2155,9 @@ msgstr "Statična stranica bez javascripta"
 msgid "Status"
 msgstr "Stanje"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Pododjeljak"
 
@@ -2333,6 +2345,9 @@ msgstr "I preuzmi nadogradnje iz ove stranice."
 msgid "There are failed jobs"
 msgstr "Ima neuspjelih zadataka"
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Ovim tekstovima nedostaje jedinstveni id."
 
@@ -2470,8 +2485,8 @@ msgstr "Za brzo oblikovanje drama upotrijebi"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Za nastavak uređivanja, možeš ići na ovaj URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2870,12 +2885,6 @@ msgstr "bilo koja"
 
 msgid "automatically generated if not present, using author and title"
 msgstr "automatski generiran ako nedostaje, s autorom i naslovom"
-
-msgid "By number of pages, ascending"
-msgstr "Po broju stranica (manje na početku)"
-
-msgid "By number of pages, descending"
-msgstr "Po broju stranica (više na početku)"
 
 msgid "code and monospace"
 msgstr "oblikovanje koda"

--- a/lib/AmuseWikiFarm/I18N/id.po
+++ b/lib/AmuseWikiFarm/I18N/id.po
@@ -135,8 +135,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -289,6 +289,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -329,8 +335,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -783,6 +789,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -866,14 +875,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -982,8 +991,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1376,8 +1385,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1984,6 +1993,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2156,6 +2168,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2283,8 +2298,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2642,12 +2657,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/it.po
+++ b/lib/AmuseWikiFarm/I18N/it.po
@@ -150,8 +150,8 @@ msgid ""
 msgstr ""
 "Informazioni aggiuntive (data completa, titolo originale, traduttori, ecc.)"
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -322,6 +322,12 @@ msgstr ""
 "parentesi. Con questa opzione verrà usata una numerazione alfabetica\n"
 "per pagina. (La prima nota secondaria di ogni pagina sarà \"a\")"
 
+msgid "By number of pages, ascending"
+msgstr "Per numero di pagine (da minore a maggiore)"
+
+msgid "By number of pages, descending"
+msgstr "Per numero di pagine (da maggiore a minore)"
+
 msgid "By relevance"
 msgstr "Rilevanza"
 
@@ -362,8 +368,8 @@ msgid "Changes applied"
 msgstr "Modifiche applicate"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Modifiche per %1"
 
@@ -854,6 +860,9 @@ msgstr ""
 "letteralmente. Fai attenzione a ciò che fai, dato che puoi inserire\n"
 "qualsiasi cosa (codice, script, ecc.)"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "Codice HTML da inserire nella colonna di sinistra"
 
@@ -946,14 +955,14 @@ msgstr "Canale IRC su Freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Se non impostato, %1 sarà cercato nella directory dell'applicazione."
 
@@ -1101,8 +1110,8 @@ msgstr ""
 "Nel testo, un numero tra parentesi quadre è interpretato come un\n"
 "riferimento a una nota a piè di pagina, se tale nota esiste."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1534,8 +1543,8 @@ msgstr "Logo PDF"
 msgid "PDFs cannot be used in the body."
 msgstr "I PDF non possono essere usati all'interno del testo."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr "I PDF non elencatine nella direttiva %1 saranno salvati ma ignorati."
 
@@ -2206,6 +2215,9 @@ msgstr "Pagina statica senza javascript"
 msgid "Status"
 msgstr "Status"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Sottosezione"
 
@@ -2403,6 +2415,9 @@ msgstr "Poi recupera gli aggiornamenti da questa pagina."
 msgid "There are failed jobs"
 msgstr "Ci sono lavori falliti"
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Questi testi sono senza identificativo."
 
@@ -2546,8 +2561,8 @@ msgstr "Per formattare pezzi teatrali, usa"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Per riprendere la modifica, puoi visitare il seguente URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2961,12 +2976,6 @@ msgstr "qualsiasi"
 
 msgid "automatically generated if not present, using author and title"
 msgstr "generato automaticamente se non presente, usando autore e titolo"
-
-msgid "By number of pages, ascending"
-msgstr "Per numero di pagine (da minore a maggiore)"
-
-msgid "By number of pages, descending"
-msgstr "Per numero di pagine (da maggiore a minore)"
 
 msgid "code and monospace"
 msgstr "formattazione codice"

--- a/lib/AmuseWikiFarm/I18N/messages.pot
+++ b/lib/AmuseWikiFarm/I18N/messages.pot
@@ -114,7 +114,7 @@ msgstr ""
 msgid "Add a cover image (PNG or JPG)"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Edit.pm:64 root/src/layout.tt:298 root/src/layout.tt:582 root/src/layout.tt:585 root/src/layout.tt:726
+#: lib/AmuseWikiFarm/Controller/Edit.pm:64 root/src/layout.tt:298 root/src/layout.tt:587 root/src/layout.tt:590 root/src/layout.tt:732
 msgid "Add a new text"
 msgstr ""
 
@@ -166,8 +166,8 @@ msgstr ""
 msgid "Additional information (full date, original title, translators, credits, etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 #: root/src/help/faq.tt:76 root/src/help/faq.tt:77
 msgid ""
 "After the approval of the\n"
@@ -197,7 +197,7 @@ msgstr ""
 msgid "All languages"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Publish.pm:96 root/src/layout.tt:423
+#: lib/AmuseWikiFarm/Controller/Publish.pm:96 root/src/layout.tt:428
 msgid "All revisions"
 msgstr ""
 
@@ -229,7 +229,7 @@ msgid ""
 "      not needed"
 msgstr ""
 
-#: root/src/admin/edit.tt:1080
+#: root/src/admin/edit.tt:1094
 msgid "Apache is not currently supported"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Attached images"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Attachments.pm:33 mkits/commit/body.txt:28 root/src/layout.tt:441 root/src/publish/pending.tt:16
+#: lib/AmuseWikiFarm/Controller/Attachments.pm:33 mkits/commit/body.txt:28 root/src/layout.tt:446 root/src/publish/pending.tt:16
 msgid "Attachments"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Author and title. If one side document: title."
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Category.pm:83 lib/AmuseWikiFarm/Controller/OPDS.pm:178 lib/AmuseWikiFarm/Controller/OPDS.pm:64 root/src/edit/preview.tt:25 root/src/include/preamble.tt:37 root/src/layout.tt:240 root/src/layout.tt:705
+#: lib/AmuseWikiFarm/Controller/Category.pm:83 lib/AmuseWikiFarm/Controller/OPDS.pm:178 lib/AmuseWikiFarm/Controller/OPDS.pm:64 root/src/edit/preview.tt:25 root/src/include/preamble.tt:37 root/src/layout.tt:240 root/src/layout.tt:711
 msgid "Authors"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Automatically generated"
 msgstr ""
 
-#: root/src/admin/edit.tt:1071
+#: root/src/admin/edit.tt:1085
 msgid "Automatically request and renew SSL certificates from Let's Encrypt"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Bold"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/BookBuilder.pm:36 root/src/layout.tt:545 root/src/layout.tt:549
+#: lib/AmuseWikiFarm/Controller/BookBuilder.pm:36 root/src/layout.tt:550 root/src/layout.tt:554
 msgid "Bookbuilder"
 msgstr ""
 
@@ -358,6 +358,14 @@ msgid ""
 "By default, secondary footnotes use arabic numbering\n"
 "        between parens. With this option they will use per-page alpha\n"
 "        numbering"
+msgstr ""
+
+#: lib/AmuseWikiFarm/Schema/ResultSet/Title.pm:439 root/src/search/index.tt:71
+msgid "By number of pages, ascending"
+msgstr ""
+
+#: lib/AmuseWikiFarm/Schema/ResultSet/Title.pm:449 root/src/search/index.tt:74
+msgid "By number of pages, descending"
 msgstr ""
 
 #: root/src/search/index.tt:56
@@ -413,8 +421,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 #: lib/AmuseWikiFarm/Controller/Edit.pm:583 mkits/commit/body.txt:1 root/src/edit/diff.tt:4
 msgid "Changes for %1"
 msgstr ""
@@ -510,7 +518,7 @@ msgstr ""
 msgid "Create a new format"
 msgstr ""
 
-#: root/src/layout.tt:459 root/src/user/create.tt:4
+#: root/src/layout.tt:464 root/src/user/create.tt:4
 msgid "Create a new librarian"
 msgstr ""
 
@@ -575,7 +583,7 @@ msgstr ""
 msgid "Default sorting for the category text list"
 msgstr ""
 
-#: root/src/layout.tt:429
+#: root/src/layout.tt:434
 msgid "Deferred/Deleted texts"
 msgstr ""
 
@@ -696,11 +704,11 @@ msgstr ""
 msgid "Edit format %1"
 msgstr ""
 
-#: root/src/layout.tt:505
+#: root/src/layout.tt:510
 msgid "Edit full site configuration"
 msgstr ""
 
-#: root/src/admin/edit.tt:1025 root/src/layout.tt:471 root/src/user/edit_options.tt:5
+#: root/src/admin/edit.tt:1039 root/src/layout.tt:476 root/src/user/edit_options.tt:5
 msgid "Edit screen layout options"
 msgstr ""
 
@@ -709,7 +717,7 @@ msgstr ""
 msgid "Edit site %1"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Settings.pm:39 root/src/layout.tt:479
+#: lib/AmuseWikiFarm/Controller/Settings.pm:39 root/src/layout.tt:484
 msgid "Edit site configuration"
 msgstr ""
 
@@ -959,7 +967,7 @@ msgstr ""
 msgid "Full list of texts"
 msgstr ""
 
-#: root/src/admin/edit.tt:951
+#: root/src/admin/edit.tt:965
 msgid "Full tag cloud"
 msgstr ""
 
@@ -996,11 +1004,15 @@ msgid ""
 "            be careful"
 msgstr ""
 
-#: root/src/admin/edit.tt:922
-msgid "HTML to insert into the left sidebar"
+#: root/src/admin/edit.tt:921
+msgid "HTML to insert in the footer of the layout, below the links"
 msgstr ""
 
 #: root/src/admin/edit.tt:936
+msgid "HTML to insert into the left sidebar"
+msgstr ""
+
+#: root/src/admin/edit.tt:950
 msgid "HTML to insert into the right sidebar"
 msgstr ""
 
@@ -1102,15 +1114,15 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
-#: root/src/admin/edit.tt:1094 root/src/admin/edit.tt:1108 root/src/admin/edit.tt:1122 root/src/admin/edit.tt:1136
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
+#: root/src/admin/edit.tt:1108 root/src/admin/edit.tt:1122 root/src/admin/edit.tt:1136 root/src/admin/edit.tt:1150
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -1162,7 +1174,7 @@ msgstr ""
 msgid "If you asked for imposition, select an imposition schema"
 msgstr ""
 
-#: root/src/admin/edit.tt:1161 root/src/tasks/rebuild.tt:3
+#: root/src/admin/edit.tt:1175 root/src/tasks/rebuild.tt:3
 msgid ""
 "If you edit some format options, like fonts or paper\n"
 "      dimensions, you may want to rebuild the generated files"
@@ -1237,8 +1249,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 #: root/src/help/opds.tt:59
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
@@ -1311,7 +1323,7 @@ msgstr ""
 msgid "Job rescheduled"
 msgstr ""
 
-#: root/src/layout.tt:491
+#: root/src/layout.tt:496
 msgid "Job status"
 msgstr ""
 
@@ -1319,7 +1331,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: root/src/layout.tt:523
+#: root/src/layout.tt:528
 msgid "Jobs (all sites)"
 msgstr ""
 
@@ -1375,7 +1387,7 @@ msgstr ""
 msgid "Last updated"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Latest.pm:58 lib/AmuseWikiFarm/Controller/OPDS.pm:113 lib/AmuseWikiFarm/Controller/OPDS.pm:70 root/src/admin/edit.tt:559 root/src/layout.tt:271 root/src/layout.tt:272 root/src/layout.tt:717 root/src/text.tt:148
+#: lib/AmuseWikiFarm/Controller/Latest.pm:58 lib/AmuseWikiFarm/Controller/OPDS.pm:113 lib/AmuseWikiFarm/Controller/OPDS.pm:70 root/src/admin/edit.tt:559 root/src/layout.tt:271 root/src/layout.tt:272 root/src/layout.tt:723 root/src/text.tt:148
 msgid "Latest entries"
 msgstr ""
 
@@ -1440,7 +1452,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: root/src/layout.tt:536
+#: root/src/layout.tt:541
 msgid "Logout"
 msgstr ""
 
@@ -1476,7 +1488,7 @@ msgstr ""
 msgid "Main text"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Help.pm:40 root/src/help/faq.tt:2 root/src/layout.tt:530
+#: lib/AmuseWikiFarm/Controller/Help.pm:40 root/src/help/faq.tt:2 root/src/layout.tt:535
 msgid "Maintainer's FAQ"
 msgstr ""
 
@@ -1492,7 +1504,7 @@ msgstr ""
 msgid "Make all non-breaking spaces explicit and visible as ~~"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Console.pm:282 root/src/layout.tt:435
+#: lib/AmuseWikiFarm/Controller/Console.pm:282 root/src/layout.tt:440
 msgid "Manage categories"
 msgstr ""
 
@@ -1516,11 +1528,11 @@ msgstr ""
 msgid "Missing redirection"
 msgstr ""
 
-#: root/src/layout.tt:557 root/src/layout.tt:721
+#: root/src/layout.tt:562 root/src/layout.tt:727
 msgid "Mobile"
 msgstr ""
 
-#: root/src/layout.tt:560
+#: root/src/layout.tt:565
 msgid "Mobile applications"
 msgstr ""
 
@@ -1746,8 +1758,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 #: root/src/edit/edit.tt:745
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
@@ -2041,7 +2053,7 @@ msgstr ""
 msgid "Produced"
 msgstr ""
 
-#: root/src/console/unpublished.tt:14 root/src/include/preamble.tt:63 root/src/include/preamble.tt:7
+#: mkits/publish/body.txt:3 root/src/console/unpublished.tt:14 root/src/include/preamble.tt:63 root/src/include/preamble.tt:7
 msgid "Publication date"
 msgstr ""
 
@@ -2088,15 +2100,15 @@ msgstr ""
 msgid "Quotes"
 msgstr ""
 
-#: root/src/admin/edit.tt:1001
+#: root/src/admin/edit.tt:1015
 msgid "RSS aggregator"
 msgstr ""
 
-#: root/src/layout.tt:565 root/src/layout.tt:568 root/src/layout.tt:693
+#: root/src/layout.tt:570 root/src/layout.tt:573 root/src/layout.tt:699
 msgid "RSS feed"
 msgstr ""
 
-#: root/src/layout.tt:573 root/src/layout.tt:576 root/src/layout.tt:689
+#: root/src/layout.tt:578 root/src/layout.tt:581 root/src/layout.tt:695
 msgid "Random"
 msgstr ""
 
@@ -2128,11 +2140,11 @@ msgstr ""
 msgid "Reason for deletion"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Schema/Result/Site.pm:3774 root/src/tasks/rebuild.tt:26
+#: lib/AmuseWikiFarm/Schema/Result/Site.pm:3778 root/src/tasks/rebuild.tt:26
 msgid "Rebuild"
 msgstr ""
 
-#: root/src/layout.tt:485
+#: root/src/layout.tt:490
 msgid "Rebuild all generated files"
 msgstr ""
 
@@ -2148,7 +2160,7 @@ msgstr ""
 msgid "Recheck"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Console.pm:207 root/src/console/alias_display.tt:3 root/src/layout.tt:453
+#: lib/AmuseWikiFarm/Controller/Console.pm:207 root/src/console/alias_display.tt:3 root/src/layout.tt:458
 msgid "Redirections"
 msgstr ""
 
@@ -2170,7 +2182,7 @@ msgstr ""
 msgid "Remote repository %1 removed"
 msgstr ""
 
-#: root/src/layout.tt:447
+#: root/src/layout.tt:452
 msgid "Remotes"
 msgstr ""
 
@@ -2259,23 +2271,23 @@ msgstr ""
 msgid "Running headings"
 msgstr ""
 
-#: root/src/admin/edit.tt:1128
+#: root/src/admin/edit.tt:1142
 msgid "SSL CA certificate path (Apache)"
 msgstr ""
 
-#: root/src/admin/edit.tt:1114
+#: root/src/admin/edit.tt:1128
 msgid "SSL certificate path (Apache)"
 msgstr ""
 
-#: root/src/admin/edit.tt:1100
+#: root/src/admin/edit.tt:1114
 msgid "SSL chained certificate path (Nginx)"
 msgstr ""
 
-#: root/src/admin/edit.tt:1042
+#: root/src/admin/edit.tt:1056
 msgid "SSL configuration"
 msgstr ""
 
-#: root/src/admin/edit.tt:1086
+#: root/src/admin/edit.tt:1100
 msgid "SSL key path"
 msgstr ""
 
@@ -2428,7 +2440,7 @@ msgstr ""
 msgid "Site slogan"
 msgstr ""
 
-#: root/src/admin/show_user_details.tt:54 root/src/admin/show_users.tt:14 root/src/layout.tt:517
+#: root/src/admin/show_user_details.tt:54 root/src/admin/show_users.tt:14 root/src/layout.tt:522
 msgid "Sites"
 msgstr ""
 
@@ -2529,6 +2541,10 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+#: mkits/publish/body.txt:4
+msgid "Status changed"
+msgstr ""
+
 #: root/src/edit/edit.tt:396
 msgid "Subsection"
 msgstr ""
@@ -2575,11 +2591,11 @@ msgstr ""
 msgid "Tables"
 msgstr ""
 
-#: root/src/admin/edit.tt:964
+#: root/src/admin/edit.tt:978
 msgid "Tag cloud with authors"
 msgstr ""
 
-#: root/src/admin/edit.tt:976
+#: root/src/admin/edit.tt:990
 msgid "Tag cloud with topics"
 msgstr ""
 
@@ -2660,11 +2676,11 @@ msgstr ""
 msgid "The following settings provide the defaults for each format."
 msgstr ""
 
-#: root/src/admin/edit.tt:1078
+#: root/src/admin/edit.tt:1092
 msgid "The following values are used to generate the webserver configuration."
 msgstr ""
 
-#: root/src/admin/edit.tt:1062
+#: root/src/admin/edit.tt:1076
 msgid ""
 "The generate webserver configuration will redirect\n"
 "          all the HTTP requests to HTTPS"
@@ -2711,11 +2727,11 @@ msgstr ""
 msgid "The text to show on the homepage preview"
 msgstr ""
 
-#: root/src/layout.tt:634
+#: root/src/layout.tt:639
 msgid "The text was added to the bookbuilder"
 msgstr ""
 
-#: root/src/edit/edit.tt:674 root/src/edit/edit.tt:675
+#: root/src/edit/edit.tt:675
 msgid ""
 "The title of the document, for sorting purposes. Useful\n"
 "          if you want to strip the article, if any. A text titled “A\n"
@@ -2743,8 +2759,12 @@ msgstr ""
 msgid "Then fetch the updates from this page."
 msgstr ""
 
-#: root/src/layout.tt:493
+#: root/src/layout.tt:498
 msgid "There are failed jobs"
+msgstr ""
+
+#: root/src/layout.tt:419
+msgid "There are pending revisions"
 msgstr ""
 
 #: root/src/console/translations.tt:21
@@ -2755,7 +2775,7 @@ msgstr ""
 msgid "They have the same syntax (images are actually links)"
 msgstr ""
 
-#: root/src/admin/edit.tt:1079
+#: root/src/admin/edit.tt:1093
 msgid "They should be paths relative to the webserver configuration root or absolute paths (recommended)."
 msgstr ""
 
@@ -2878,7 +2898,7 @@ msgstr ""
 msgid "Title, author, date..."
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/OPDS.pm:100 lib/AmuseWikiFarm/Controller/OPDS.pm:254 lib/AmuseWikiFarm/Controller/OPDS.pm:53 lib/AmuseWikiFarm/Controller/OPDS.pm:76 root/src/layout.tt:232 root/src/layout.tt:698
+#: lib/AmuseWikiFarm/Controller/OPDS.pm:100 lib/AmuseWikiFarm/Controller/OPDS.pm:254 lib/AmuseWikiFarm/Controller/OPDS.pm:53 lib/AmuseWikiFarm/Controller/OPDS.pm:76 root/src/layout.tt:232 root/src/layout.tt:704
 msgid "Titles"
 msgstr ""
 
@@ -2907,8 +2927,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 #: root/src/bookbuilder/index.tt:231
 msgid ""
 "To save or update the templates, you need first to save\n"
@@ -2927,7 +2947,7 @@ msgstr ""
 msgid "Topic"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Category.pm:79 lib/AmuseWikiFarm/Controller/OPDS.pm:136 lib/AmuseWikiFarm/Controller/OPDS.pm:59 root/src/edit/edit.tt:685 root/src/edit/newtext.tt:92 root/src/edit/preview.tt:39 root/src/include/preamble.tt:80 root/src/layout.tt:247 root/src/layout.tt:263 root/src/layout.tt:712
+#: lib/AmuseWikiFarm/Controller/Category.pm:79 lib/AmuseWikiFarm/Controller/OPDS.pm:136 lib/AmuseWikiFarm/Controller/OPDS.pm:59 root/src/edit/edit.tt:685 root/src/edit/newtext.tt:92 root/src/edit/preview.tt:39 root/src/include/preamble.tt:80 root/src/layout.tt:247 root/src/layout.tt:263 root/src/layout.tt:718
 msgid "Topics"
 msgstr ""
 
@@ -3024,11 +3044,11 @@ msgstr ""
 msgid "Unused attachment"
 msgstr ""
 
-#: root/src/admin/edit.tt:1149 root/src/admin/show_user_details.tt:70 root/src/attachments/edit.tt:33 root/src/bookbuilder/index.tt:203 root/src/bookbuilder/index.tt:231 root/src/category-details-edit.tt:41 root/src/settings/edit_format.tt:37 root/src/user/edit.tt:39 root/src/user/edit_options.tt:19
+#: root/src/admin/edit.tt:1163 root/src/admin/show_user_details.tt:70 root/src/attachments/edit.tt:33 root/src/bookbuilder/index.tt:203 root/src/bookbuilder/index.tt:231 root/src/category-details-edit.tt:41 root/src/settings/edit_format.tt:37 root/src/user/edit.tt:39 root/src/user/edit_options.tt:19
 msgid "Update"
 msgstr ""
 
-#: root/src/layout.tt:465
+#: root/src/layout.tt:470
 msgid "Update account info"
 msgstr ""
 
@@ -3056,7 +3076,7 @@ msgstr ""
 msgid "Use LuaLaTeX instead of XeLaTeX (slower)"
 msgstr ""
 
-#: root/src/admin/edit.tt:1054
+#: root/src/admin/edit.tt:1068
 msgid "Use SSL for authenticated users"
 msgstr ""
 
@@ -3077,7 +3097,7 @@ msgstr ""
 msgid "Use the image as cover"
 msgstr ""
 
-#: root/src/admin/edit.tt:948
+#: root/src/admin/edit.tt:962
 msgid "Useful HTML snippets"
 msgstr ""
 
@@ -3112,7 +3132,7 @@ msgstr ""
 msgid "Username, alphanumerical only, no special characters, no uppercase"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/Admin.pm:211 root/src/layout.tt:511
+#: lib/AmuseWikiFarm/Controller/Admin.pm:211 root/src/layout.tt:516
 msgid "Users"
 msgstr ""
 
@@ -3355,14 +3375,6 @@ msgstr ""
 msgid "automatically generated if not present, using author and title"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Schema/ResultSet/Title.pm:439 root/src/search/index.tt:71
-msgid "By number of pages, ascending"
-msgstr ""
-
-#: lib/AmuseWikiFarm/Schema/ResultSet/Title.pm:449 root/src/search/index.tt:74
-msgid "By number of pages, descending"
-msgstr ""
-
 #: root/src/edit/edit.tt:476 root/src/edit/edit.tt:477 root/src/edit/edit.tt:479
 msgid "code and monospace"
 msgstr ""
@@ -3536,15 +3548,15 @@ msgstr ""
 msgid "texts by authors, title, topic..."
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/OPDS.pm:179 lib/AmuseWikiFarm/Controller/OPDS.pm:223 lib/AmuseWikiFarm/Controller/OPDS.pm:65 root/src/layout.tt:239 root/src/layout.tt:705
+#: lib/AmuseWikiFarm/Controller/OPDS.pm:179 lib/AmuseWikiFarm/Controller/OPDS.pm:223 lib/AmuseWikiFarm/Controller/OPDS.pm:65 root/src/layout.tt:239 root/src/layout.tt:711
 msgid "texts sorted by author"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/OPDS.pm:255 lib/AmuseWikiFarm/Controller/OPDS.pm:54 root/src/layout.tt:231 root/src/layout.tt:698
+#: lib/AmuseWikiFarm/Controller/OPDS.pm:255 lib/AmuseWikiFarm/Controller/OPDS.pm:54 root/src/layout.tt:231 root/src/layout.tt:704
 msgid "texts sorted by title"
 msgstr ""
 
-#: lib/AmuseWikiFarm/Controller/OPDS.pm:137 lib/AmuseWikiFarm/Controller/OPDS.pm:60 root/src/layout.tt:262 root/src/layout.tt:712
+#: lib/AmuseWikiFarm/Controller/OPDS.pm:137 lib/AmuseWikiFarm/Controller/OPDS.pm:60 root/src/layout.tt:262 root/src/layout.tt:718
 msgid "texts sorted by topics"
 msgstr ""
 

--- a/lib/AmuseWikiFarm/I18N/mk.po
+++ b/lib/AmuseWikiFarm/I18N/mk.po
@@ -151,8 +151,8 @@ msgid ""
 msgstr ""
 "Дополнителни информации (полн датум, наслов на оригиналот, преведувачи, итн.)"
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -323,6 +323,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -363,8 +369,8 @@ msgid "Changes applied"
 msgstr "Внесени измени"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Измени за %1"
 
@@ -848,6 +854,9 @@ msgstr ""
 "Додади го следниот HTML кај секоја посебна страница (/special/*), без\n"
 " никакви промени (внимавај што правиш)."
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML за левата страна на секоја страница"
 
@@ -938,14 +947,14 @@ msgstr "IRC канал на мрежата Freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Ако е празно, ќе се користи %1 од директориумот на апликацијата."
 
@@ -1089,8 +1098,8 @@ msgstr ""
 "Во текстот бројката во средни загради се толкува како фуснота, доколку таа "
 "фуснота постои ."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1508,8 +1517,8 @@ msgstr "PDF лого"
 msgid "PDFs cannot be used in the body."
 msgstr "Не е можно да се користат PDF датотеки во самите текстови."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 "PDF датотеките кои не се на листата %1 ќе бидат зачувани, но игнорирани."
@@ -2178,6 +2187,9 @@ msgstr "Статична страница без javascript"
 msgid "Status"
 msgstr "Состојба"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Пододдел"
 
@@ -2367,6 +2379,9 @@ msgstr "И преземи ги надградбите од оваа страни
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "На овие текстови им недостига единствениот id."
 
@@ -2508,8 +2523,8 @@ msgstr "За брзо обликување на драми, употреби"
 msgid "To resume the editing you can visit the following URL"
 msgstr "За да го продолжиш уредувањето, можеш да одиш на овој URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2914,12 +2929,6 @@ msgstr "која било"
 
 msgid "automatically generated if not present, using author and title"
 msgstr "се генерира автоматски доколку недостига, со автор и наслов"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "обликување на кодот"

--- a/lib/AmuseWikiFarm/I18N/nl.po
+++ b/lib/AmuseWikiFarm/I18N/nl.po
@@ -155,8 +155,8 @@ msgstr ""
 "Extra informatie (volledige datum,  originele titel, vertalers, erkenningen, "
 "etc.)"
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -332,6 +332,12 @@ msgstr ""
 "        nummers tussen haakjes. Met deze optie gebruiken ze\n"
 "        alfa nummering per pagina"
 
+msgid "By number of pages, ascending"
+msgstr "Op aantal pagina's, oplopend"
+
+msgid "By number of pages, descending"
+msgstr "Op aantal pagina's, aflopend"
+
 msgid "By relevance"
 msgstr "Op relevantie"
 
@@ -372,8 +378,8 @@ msgid "Changes applied"
 msgstr "Toegepaste wijziginen"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Wijzigingen voor %1"
 
@@ -871,6 +877,9 @@ msgstr ""
 "verpesten,\n"
 "            dus wees voorzichting"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML om in te voegen in de linker zijbalk"
 
@@ -964,14 +973,14 @@ msgstr "IRC kanaal op freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Als %1 niet is ingesteld wordt het opgezocht in de programma index."
 
@@ -1124,8 +1133,8 @@ msgstr ""
 "In de tekst wordt een getal binnen vierkante haakjes geinterpreteerd\n"
 "          een referentie naar een voetnoet, voorzover zo'n voetnoot bestaat."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1557,8 +1566,8 @@ msgstr "PDF logo"
 msgid "PDFs cannot be used in the body."
 msgstr "PDFs kunnen niet in de hoofdtekst worden gebruikt."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 "PDFs niet niet vermeld staan in de %1 instructie worden wel opgeslagen maar "
@@ -2232,6 +2241,9 @@ msgstr "Statische pagina zonder javascript"
 msgid "Status"
 msgstr "Status"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Subsectie"
 
@@ -2432,6 +2444,9 @@ msgstr "Haal dan de updates van deze pagina."
 msgid "There are failed jobs"
 msgstr "Er zijn mislukte taken"
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Deze teksten missen de unieke id."
 
@@ -2574,8 +2589,8 @@ msgstr "Om snel toneelstukken op te maken gebruik je"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Om verder te gaan met bewerken ga je naar de volgende URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2998,12 +3013,6 @@ msgstr "elk"
 msgid "automatically generated if not present, using author and title"
 msgstr ""
 "automatisch gegenereerd indien niet aanwezig, op basis van auteur en titel"
-
-msgid "By number of pages, ascending"
-msgstr "Op aantal pagina's, oplopend"
-
-msgid "By number of pages, descending"
-msgstr "Op aantal pagina's, aflopend"
 
 msgid "code and monospace"
 msgstr "code en niet-proportioneel (monospace)"

--- a/lib/AmuseWikiFarm/I18N/pl.po
+++ b/lib/AmuseWikiFarm/I18N/pl.po
@@ -137,8 +137,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -291,6 +291,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -331,8 +337,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -785,6 +791,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -868,14 +877,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -984,8 +993,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1378,8 +1387,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1986,6 +1995,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2158,6 +2170,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2285,8 +2300,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2644,12 +2659,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/pt.po
+++ b/lib/AmuseWikiFarm/I18N/pt.po
@@ -152,8 +152,8 @@ msgstr ""
 "Informação adicional (data completa, título original, tradutores, créditos, "
 "etc)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -328,6 +328,12 @@ msgstr ""
 "        essa opção eles usam numeração alpha\n"
 "        por página."
 
+msgid "By number of pages, ascending"
+msgstr "Por número de páginas, ascendente"
+
+msgid "By number of pages, descending"
+msgstr "Por número de páginas, descendente"
+
 msgid "By relevance"
 msgstr "Por relevância"
 
@@ -368,8 +374,8 @@ msgid "Changes applied"
 msgstr "Mudanças aplicadas"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Mudanças para %1"
 
@@ -847,6 +853,9 @@ msgstr ""
 "               verbatim, existe a chance de estragar tudo,\n"
 "               então tome cuidado"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML a ser inserido na barra lateral esquerda"
 
@@ -940,14 +949,14 @@ msgstr "Canal do IRC no freenode"
 msgid "Id"
 msgstr "ID"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Se não estiver definido %1 vai ser buscado no diretório da aplicação."
 
@@ -1089,8 +1098,8 @@ msgstr ""
 "No texto, um número entre colchetes é interpretado como referência à nota de "
 "rodapé, se tal nota de rodapé existir."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1520,8 +1529,8 @@ msgstr "logo para PDF"
 msgid "PDFs cannot be used in the body."
 msgstr "PDFs não podem ser usandos no corpo."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr "PDFs não listados na diretiva %1 serão armazenados mas ignorados."
 
@@ -2191,6 +2200,9 @@ msgstr "Página estática sem javascript"
 msgid "Status"
 msgstr "Status"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Subseção"
 
@@ -2384,6 +2396,9 @@ msgstr "Então busca as atualizações daqui desta página."
 msgid "There are failed jobs"
 msgstr "Existem trabalhos que falharam."
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Estes textos estão sem identificador único."
 
@@ -2528,8 +2543,8 @@ msgstr "Para formatar rapidamente peças, use"
 msgid "To resume the editing you can visit the following URL"
 msgstr "Para continuar a edição você pode visitar a seguinte URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2940,12 +2955,6 @@ msgstr "algum"
 
 msgid "automatically generated if not present, using author and title"
 msgstr "gerado automaticamente se não estiver presente, usando autor e título"
-
-msgid "By number of pages, ascending"
-msgstr "Por número de páginas, ascendente"
-
-msgid "By number of pages, descending"
-msgstr "Por número de páginas, descendente"
 
 msgid "code and monospace"
 msgstr "código e monoespaçamento"

--- a/lib/AmuseWikiFarm/I18N/ru.po
+++ b/lib/AmuseWikiFarm/I18N/ru.po
@@ -148,8 +148,8 @@ msgid ""
 msgstr ""
 "Дополнительная информация (дата, название в оригинале, переводчики и др.)."
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -320,6 +320,12 @@ msgstr ""
 "По умолчанию дополнительные сноски используют арабские цифры в скобках. С "
 "этой опцией они будут использовать постраничную нумерацию буквами"
 
+msgid "By number of pages, ascending"
+msgstr "По возрастанию числа страниц"
+
+msgid "By number of pages, descending"
+msgstr "По убыванию числа страниц"
+
 msgid "By relevance"
 msgstr "По релевантности"
 
@@ -360,8 +366,8 @@ msgid "Changes applied"
 msgstr "Изменения применены"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Изменения для %1"
 
@@ -844,6 +850,9 @@ msgstr ""
 "HTML для вставки на каждой специальной странице, вставляется без обработки, "
 "у вас есть шанс испортить разметку, поэтому будьте осторожны"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML для вставки в левую боковую панель"
 
@@ -935,14 +944,14 @@ msgstr "IRC-канал на Freenode"
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Если не указано, будем искать %1 относительно директории приложения."
 
@@ -1083,8 +1092,8 @@ msgstr ""
 "В тексте номер в квадратных скобках воспринимается как\n"
 " номер сноски, если сноска существует. "
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1504,8 +1513,8 @@ msgstr "Логотип PDF"
 msgid "PDFs cannot be used in the body."
 msgstr "PDF не могут быть использованы в теле текста"
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr "PDF не прописанные в %1 будут сохранены но проигнорированы"
 
@@ -2493,8 +2502,8 @@ msgstr "Для быстрого форматирования пьес испол
 msgid "To resume the editing you can visit the following URL"
 msgstr "Для продолжения редактирования пройдите по следующей ссылке"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2904,12 +2913,6 @@ msgid "automatically generated if not present, using author and title"
 msgstr ""
 "если поле оставлено пустым создаётся автоматически с использованием автора и "
 "названия"
-
-msgid "By number of pages, ascending"
-msgstr "По возрастанию числа страниц"
-
-msgid "By number of pages, descending"
-msgstr "По убыванию числа страниц"
 
 msgid "code and monospace"
 msgstr "код и моноширинный"

--- a/lib/AmuseWikiFarm/I18N/sq.po
+++ b/lib/AmuseWikiFarm/I18N/sq.po
@@ -153,8 +153,8 @@ msgstr ""
 "Informatat shtesë (data e plotë, titulli origjinal, përkthyesit, "
 "pjesëmarrësit etj.)"
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -331,6 +331,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -371,8 +377,8 @@ msgid "Changes applied"
 msgstr "Ndryshimet u aplikuan"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Ndryshime për %1"
 
@@ -852,6 +858,9 @@ msgstr ""
 "ashtu siç është, tani ke mundesi me prishë çdo gjë, pranaj \n"
 "ke kujdes"
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr "HTML-i të vendoset në shiritin në të majtë"
 
@@ -944,14 +953,14 @@ msgstr "Kanali IRC në freenode"
 msgid "Id"
 msgstr "ID"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr "Nëse nuk është vendosur %1 do të merret nga udhëzuesi i aplikacionit"
 
@@ -1082,8 +1091,8 @@ msgstr ""
 "Numri brenda kllapave të mesme në tekst interpretohet si\n"
 "fusnotë, nëse ezgiston një fusnote e tillë."
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1498,8 +1507,8 @@ msgstr "PDF llogo"
 msgid "PDFs cannot be used in the body."
 msgstr "PDF-at nuk mund të përdoren në trup."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr "PDF-at e pa listuar në direktivën %1 do të ruhen por do të injorohen."
 
@@ -2161,6 +2170,9 @@ msgstr "Faqja statike pa javascript"
 msgid "Status"
 msgstr "Statusi"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Nënseksioni"
 
@@ -2342,6 +2354,9 @@ msgstr "Pastaj merrini përditësimet nga kjo faqe."
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Ketyre teksteve iu mungon ID e veçantë."
 
@@ -2490,8 +2505,8 @@ msgid "To resume the editing you can visit the following URL"
 msgstr ""
 "Për të vazhduar ndryshimin e teksti, ju mund ta vizitoni linkun në vazhdim:"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2885,12 +2900,6 @@ msgid "automatically generated if not present, using author and title"
 msgstr ""
 "gjenerohet automatikisht nëse nuk është prezente duke përdorur autorin dhe "
 "titullin"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "Kodi dhe monospace"

--- a/lib/AmuseWikiFarm/I18N/sr.po
+++ b/lib/AmuseWikiFarm/I18N/sr.po
@@ -137,8 +137,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -291,6 +291,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -331,8 +337,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -785,6 +791,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -868,14 +877,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -984,8 +993,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1378,8 +1387,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1986,6 +1995,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2158,6 +2170,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2285,8 +2300,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2644,12 +2659,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/lib/AmuseWikiFarm/I18N/sv.po
+++ b/lib/AmuseWikiFarm/I18N/sv.po
@@ -145,8 +145,8 @@ msgstr ""
 "Ytterligare information (fullständigt datum, originaltitel, översättare, "
 "tillägnanden, etc.)"
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -304,6 +304,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -344,8 +350,8 @@ msgid "Changes applied"
 msgstr "Ändrigar utförda"
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr "Ändringar till %1"
 
@@ -805,6 +811,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -888,14 +897,14 @@ msgstr ""
 msgid "Id"
 msgstr "Id"
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -1008,8 +1017,8 @@ msgstr ""
 "I texten tolkas en siffra inom parentes som en fotnotsreferens,om sådan "
 "fotnot existerar. "
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1414,8 +1423,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr "PDF:er kan inte användas i brödtexten."
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr "PDF är inte listad i %1 direktiv kommer att lagras men ignoreras"
 
@@ -2061,6 +2070,9 @@ msgstr "Statisk sida utan javascript"
 msgid "Status"
 msgstr "Status"
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr "Underavdelning"
 
@@ -2241,6 +2253,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr "Dessa texter saknar det unika ID:t."
 
@@ -2371,8 +2386,8 @@ msgstr "För att snabbt formatera pjäser, använd"
 msgid "To resume the editing you can visit the following URL"
 msgstr "För att återgå till redigeringen kan du besöka denna URL"
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2743,12 +2758,6 @@ msgstr ""
 
 msgid "automatically generated if not present, using author and title"
 msgstr "genereras automatiskt om saknad, genom författare och titel"
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
-msgstr ""
 
 msgid "code and monospace"
 msgstr "kod och monospace"

--- a/lib/AmuseWikiFarm/I18N/tr.po
+++ b/lib/AmuseWikiFarm/I18N/tr.po
@@ -136,8 +136,8 @@ msgid ""
 "etc)."
 msgstr ""
 
-#. (c.uri_for_action('/console/unpublished')
 #. (c.uri_for_action("/console/unpublished").path)
+#. (c.uri_for_action('/console/unpublished')
 msgid ""
 "After the approval of the\n"
 "  change, it will appear under %1. There is a big red\n"
@@ -290,6 +290,12 @@ msgid ""
 "        numbering"
 msgstr ""
 
+msgid "By number of pages, ascending"
+msgstr ""
+
+msgid "By number of pages, descending"
+msgstr ""
+
 msgid "By relevance"
 msgstr ""
 
@@ -330,8 +336,8 @@ msgid "Changes applied"
 msgstr ""
 
 #. ($c->stash->{revision}->title->uri)
-#. (revision.title.uri)
 #. (author_title)
+#. (revision.title.uri)
 msgid "Changes for %1"
 msgstr ""
 
@@ -784,6 +790,9 @@ msgid ""
 "            be careful"
 msgstr ""
 
+msgid "HTML to insert in the footer of the layout, below the links"
+msgstr ""
+
 msgid "HTML to insert into the left sidebar"
 msgstr ""
 
@@ -867,14 +876,14 @@ msgstr ""
 msgid "Id"
 msgstr ""
 
-#. ('ssl/' _ esite.canonical _ '/key.pem')
-#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
-#. ('ssl/' _ esite.canonical _ '/cert.pem')
-#. ('ssl/' _ esite.canonical _ '/chain.pem')
 #. ("ssl/' _ esite.canonical _ '/key.pem")
 #. ("ssl/' _ esite.canonical _ '/fullchain.pem")
 #. ("ssl/' _ esite.canonical _ '/cert.pem")
 #. ("ssl/' _ esite.canonical _ '/chain.pem")
+#. ('ssl/' _ esite.canonical _ '/key.pem')
+#. ('ssl/' _ esite.canonical _ '/fullchain.pem')
+#. ('ssl/' _ esite.canonical _ '/cert.pem')
+#. ('ssl/' _ esite.canonical _ '/chain.pem')
 msgid "If not set %1 will be looked up from the application directory."
 msgstr ""
 
@@ -983,8 +992,8 @@ msgid ""
 "          footnote reference, if such footnote exists."
 msgstr ""
 
-#. (c.uri_for_action('/opds/start')
 #. (c.uri_for_action("/opds/start"))
+#. (c.uri_for_action('/opds/start')
 msgid ""
 "In this example, we use FBreader, but the procedure is\n"
 "  pretty much the same for all applications. All you have to do is to\n"
@@ -1377,8 +1386,8 @@ msgstr ""
 msgid "PDFs cannot be used in the body."
 msgstr ""
 
-#. ('#ATTACH')
 #. ("#ATTACH")
+#. ('#ATTACH')
 msgid "PDFs not listed in the %1 directive will be stored but ignored."
 msgstr ""
 
@@ -1985,6 +1994,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Status changed"
+msgstr ""
+
 msgid "Subsection"
 msgstr ""
 
@@ -2157,6 +2169,9 @@ msgstr ""
 msgid "There are failed jobs"
 msgstr ""
 
+msgid "There are pending revisions"
+msgstr ""
+
 msgid "These texts are missing the unique id."
 msgstr ""
 
@@ -2284,8 +2299,8 @@ msgstr ""
 msgid "To resume the editing you can visit the following URL"
 msgstr ""
 
-#. (loc('Update')
 #. (loc("Update"))
+#. (loc('Update')
 msgid ""
 "To save or update the templates, you need first to save\n"
 "    the options with the \"%1\" button"
@@ -2643,12 +2658,6 @@ msgid "any"
 msgstr ""
 
 msgid "automatically generated if not present, using author and title"
-msgstr ""
-
-msgid "By number of pages, ascending"
-msgstr ""
-
-msgid "By number of pages, descending"
 msgstr ""
 
 msgid "code and monospace"

--- a/script/upgrade_i18n
+++ b/script/upgrade_i18n
@@ -2,11 +2,12 @@
 
 filelist=`mktemp`
 
-find ./lib -type f -iname "*.pm" | grep -v debug_loc > $filelist
-find ./root/src -type f -iname "*.tt" | grep -v debug_loc >> $filelist
-find ./mkits -type f >> $filelist
-echo ./root/static/js/amw-batch-upload.js >> $filelist
-cat $filelist
+{
+find ./lib -type f -iname "*.pm" | grep -v debug_loc
+find ./root/src -type f -iname "*.tt" | grep -v debug_loc
+find ./mkits -type f
+echo ./root/static/js/amw-batch-upload.js
+} | sort -u | tee $filelist
 
 xgettext.pl -P perl=* -P tt2=* -P generic=js \
     --output=lib/AmuseWikiFarm/I18N/messages.pot -f $filelist


### PR DESCRIPTION
`find` does not always output filenames in the same order, so it is required to sort them to get stable output.