### PR TITLE
Cleanup "New text" page

### DIFF
--- a/lib/AmuseWikiFarm/I18N/ar.po
+++ b/lib/AmuseWikiFarm/I18N/ar.po
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/ar.po
+++ b/lib/AmuseWikiFarm/I18N/ar.po
@@ -2693,7 +2693,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/ar.po
+++ b/lib/AmuseWikiFarm/I18N/ar.po
@@ -1616,7 +1616,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/ar.po
+++ b/lib/AmuseWikiFarm/I18N/ar.po
@@ -2816,7 +2816,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/cs.po
+++ b/lib/AmuseWikiFarm/I18N/cs.po
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/cs.po
+++ b/lib/AmuseWikiFarm/I18N/cs.po
@@ -2654,7 +2654,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/cs.po
+++ b/lib/AmuseWikiFarm/I18N/cs.po
@@ -2694,7 +2694,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/cs.po
+++ b/lib/AmuseWikiFarm/I18N/cs.po
@@ -2817,7 +2817,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/da.po
+++ b/lib/AmuseWikiFarm/I18N/da.po
@@ -1767,8 +1767,8 @@ msgstr "Produceret"
 msgid "Publication date"
 msgstr "Udgivelsesdato"
 
-msgid "Publication date on this site."
-msgstr "Dato for offentliggørelse på denne side."
+msgid "Publication date on this site"
+msgstr "Dato for offentliggørelse på denne side"
 
 msgid "Publish"
 msgstr "Offentliggør"

--- a/lib/AmuseWikiFarm/I18N/da.po
+++ b/lib/AmuseWikiFarm/I18N/da.po
@@ -2907,11 +2907,11 @@ msgid "generic sectioning, good for articles"
 msgstr "generel sektionering, passer til artikler"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"hvis der tilfældigvis eksisterer en anden tekst med samme forfatter og "
+"Hvis der tilfældigvis eksisterer en anden tekst med samme forfatter og "
 "titel, så vælg den ønskede URI i feltet nedenfor ved at indsætte forfatter, "
 "titel og et nummer, f.eks. min-forfatter-min-titel-1"
 

--- a/lib/AmuseWikiFarm/I18N/da.po
+++ b/lib/AmuseWikiFarm/I18N/da.po
@@ -2867,8 +2867,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "kode og monospatieret"
 
-msgid "comma or semicolon separated list"
-msgstr "liste separeret af komma eller semikolon"
+msgid "Comma or semicolon separated list"
+msgstr "Liste separeret af komma eller semikolon"
 
 msgid "completed"
 msgstr "færdig"
@@ -2941,7 +2941,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "ny-eksempel-uri"
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/da.po
+++ b/lib/AmuseWikiFarm/I18N/da.po
@@ -3035,9 +3035,9 @@ msgid "without description"
 msgstr "uden beskrivelse"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"du ønsker måske at fjerne det indledende »En«, »Et«, »Den«, og så videre fra "
+"Du ønsker måske at fjerne det indledende »En«, »Et«, »Den«, og så videre fra "
 "titlen"
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/de.po
+++ b/lib/AmuseWikiFarm/I18N/de.po
@@ -2922,9 +2922,9 @@ msgid "without description"
 msgstr "ohne Beschreibung"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"du solltest Artikel am Anfang des Titels entfernen, z.B. Der, Die, Das, Ein/e"
+"Du solltest Artikel am Anfang des Titels entfernen, z.B. Der, Die, Das, Ein/e"
 
 msgid ""
 "“Stale editing” means that the revision was abandoned\n"

--- a/lib/AmuseWikiFarm/I18N/de.po
+++ b/lib/AmuseWikiFarm/I18N/de.po
@@ -2756,8 +2756,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "Code und Monospace"
 
-msgid "comma or semicolon separated list"
-msgstr "durch Komma oder Strichpunkt getrennte Liste"
+msgid "Comma or semicolon separated list"
+msgstr "Durch Komma oder Strichpunkt getrennte Liste"
 
 msgid "completed"
 msgstr "fertig gestellt"
@@ -2828,8 +2828,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
-msgstr "optional, standardmäßig nach der Anweisung der Autorin "
+msgid "Optional, defaults to the author directive"
+msgstr "Optional, standardmäßig nach der Anweisung der Autorin "
 
 msgid "or"
 msgstr "oder"

--- a/lib/AmuseWikiFarm/I18N/de.po
+++ b/lib/AmuseWikiFarm/I18N/de.po
@@ -1682,8 +1682,8 @@ msgstr "Produziert"
 msgid "Publication date"
 msgstr "Veröffentlichungsdatum"
 
-msgid "Publication date on this site."
-msgstr "Veröffentlichungsdatum auf dieser Seite."
+msgid "Publication date on this site"
+msgstr "Veröffentlichungsdatum auf dieser Seite"
 
 msgid "Publish"
 msgstr "Veröffentlichen"

--- a/lib/AmuseWikiFarm/I18N/de.po
+++ b/lib/AmuseWikiFarm/I18N/de.po
@@ -2796,11 +2796,11 @@ msgid "generic sectioning, good for articles"
 msgstr "Generische Sektionierung, gut für Artikel"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"im gegebenen Fall, dass ein Text der selben AutorIn mit dem selben Titel "
+"Im gegebenen Fall, dass ein Text der selben AutorIn mit dem selben Titel "
 "existiert, wähle die gewünschte URI, verwende dazu das untere Feld und gib "
 "die AutorIn, den Titel und eine Nummer an, z.B. meine-AutorIn-mein-Titel-1 "
 

--- a/lib/AmuseWikiFarm/I18N/en.po
+++ b/lib/AmuseWikiFarm/I18N/en.po
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/en.po
+++ b/lib/AmuseWikiFarm/I18N/en.po
@@ -2654,7 +2654,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/en.po
+++ b/lib/AmuseWikiFarm/I18N/en.po
@@ -2694,7 +2694,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/en.po
+++ b/lib/AmuseWikiFarm/I18N/en.po
@@ -2817,7 +2817,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/es.po
+++ b/lib/AmuseWikiFarm/I18N/es.po
@@ -2938,8 +2938,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "código y mono espaciado"
 
-msgid "comma or semicolon separated list"
-msgstr "lista separada por coma o punto y coma"
+msgid "Comma or semicolon separated list"
+msgstr "Lista separada por coma o punto y coma"
 
 msgid "completed"
 msgstr "completado"
@@ -3012,8 +3012,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "uri-ejemplo-nuevo"
 
-msgid "optional, defaults to the author directive"
-msgstr "opcional, de forma predeterminada es la directiva del/a autor/a"
+msgid "Optional, defaults to the author directive"
+msgstr "Opcional, de forma predeterminada es la directiva del/a autor/a"
 
 msgid "or"
 msgstr "o"

--- a/lib/AmuseWikiFarm/I18N/es.po
+++ b/lib/AmuseWikiFarm/I18N/es.po
@@ -1799,7 +1799,7 @@ msgstr "Producido"
 msgid "Publication date"
 msgstr "Fecha de publicación"
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr "Fecha de publicación en este sitio"
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/es.po
+++ b/lib/AmuseWikiFarm/I18N/es.po
@@ -3108,9 +3108,9 @@ msgid "without description"
 msgstr "sin descripción"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"quizás quieras quitar los artículos iniciales \"Un\", \"Una\", \"Las\", etc. "
+"Quizás quieras quitar los artículos iniciales \"Un\", \"Una\", \"Las\", etc. "
 "del título"
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/es.po
+++ b/lib/AmuseWikiFarm/I18N/es.po
@@ -2978,11 +2978,11 @@ msgid "generic sectioning, good for articles"
 msgstr "división genérica, útil para artículos"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"si es que existe otro texto del/a mismo/a autor/a y mismo título, elige la "
+"Si es que existe otro texto del/a mismo/a autor/a y mismo título, elige la "
 "URI deseada usando el campo de abajo insertando autor/a, título y un número, "
 "por ejemplo mi-autora-mi-titulo-1"
 

--- a/lib/AmuseWikiFarm/I18N/fa.po
+++ b/lib/AmuseWikiFarm/I18N/fa.po
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/fa.po
+++ b/lib/AmuseWikiFarm/I18N/fa.po
@@ -2693,7 +2693,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/fa.po
+++ b/lib/AmuseWikiFarm/I18N/fa.po
@@ -1616,7 +1616,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/fa.po
+++ b/lib/AmuseWikiFarm/I18N/fa.po
@@ -2816,7 +2816,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/fi.po
+++ b/lib/AmuseWikiFarm/I18N/fi.po
@@ -2897,7 +2897,7 @@ msgid "without description"
 msgstr "ilman kuvausta"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr " "
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/fi.po
+++ b/lib/AmuseWikiFarm/I18N/fi.po
@@ -2731,8 +2731,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "koodi ja tasavälinen teksti"
 
-msgid "comma or semicolon separated list"
-msgstr "pilkulla tai puolipisteellä erotettu lista"
+msgid "Comma or semicolon separated list"
+msgstr "Pilkulla tai puolipisteellä erotettu lista"
 
 msgid "completed"
 msgstr "valmis"
@@ -2803,8 +2803,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
-msgstr "vapaaehtoinen, oletuksena kirjoittajamerkintä"
+msgid "Optional, defaults to the author directive"
+msgstr "Vapaaehtoinen, oletuksena kirjoittajamerkintä"
 
 msgid "or"
 msgstr "tai"

--- a/lib/AmuseWikiFarm/I18N/fi.po
+++ b/lib/AmuseWikiFarm/I18N/fi.po
@@ -2771,11 +2771,11 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"jos jostain syystä olisi toinen teksti samalla otsikolla ja kirjoittajan "
+"Jos jostain syystä olisi toinen teksti samalla otsikolla ja kirjoittajan "
 "nimellä, valitse haluttu URI laittamalla alla olevaan kenttään kirjoittaja, "
 "otsikko ja numero, esim. kirjoittaja-otsikko-1"
 

--- a/lib/AmuseWikiFarm/I18N/fi.po
+++ b/lib/AmuseWikiFarm/I18N/fi.po
@@ -1671,8 +1671,8 @@ msgstr ""
 msgid "Publication date"
 msgstr "Julkaisuajankohta"
 
-msgid "Publication date on this site."
-msgstr "Julkaisupäivä tällä sivustolla."
+msgid "Publication date on this site"
+msgstr "Julkaisupäivä tällä sivustolla"
 
 msgid "Publish"
 msgstr "Julkaise"

--- a/lib/AmuseWikiFarm/I18N/fr.po
+++ b/lib/AmuseWikiFarm/I18N/fr.po
@@ -3127,9 +3127,9 @@ msgid "without description"
 msgstr "sans description"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"vous souhaitez peut-être retirer le premier mot du titre s'il s'agit de \"Un"
+"Vous souhaitez peut-être retirer le premier mot du titre s'il s'agit de \"Un"
 "\", \"Le\", etc"
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/fr.po
+++ b/lib/AmuseWikiFarm/I18N/fr.po
@@ -2997,11 +2997,11 @@ msgid "generic sectioning, good for articles"
 msgstr "sectionnement générique, bon pour les articles"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"si par hasard il existe un autre texte avec les même auteur·e et titre, "
+"Si par hasard il existe un autre texte avec les même auteur·e et titre, "
 "définissez aussi un URI en bas de page à partir de l'auteur·e, du titre et "
 "d'un chiffre, par exemple mon-auteure-mon-titre-1"
 

--- a/lib/AmuseWikiFarm/I18N/fr.po
+++ b/lib/AmuseWikiFarm/I18N/fr.po
@@ -2957,8 +2957,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "code et caractères à espacement fixe"
 
-msgid "comma or semicolon separated list"
-msgstr "liste séparée par virgules ou deux-points"
+msgid "Comma or semicolon separated list"
+msgstr "Liste séparée par virgules ou deux-points"
 
 msgid "completed"
 msgstr "complété"
@@ -3031,8 +3031,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "nouvel-exemple-uri"
 
-msgid "optional, defaults to the author directive"
-msgstr "facultatif, prend par défaut la valeur de la directive #author"
+msgid "Optional, defaults to the author directive"
+msgstr "Facultatif, prend par défaut la valeur de la directive #author"
 
 msgid "or"
 msgstr "ou"

--- a/lib/AmuseWikiFarm/I18N/fr.po
+++ b/lib/AmuseWikiFarm/I18N/fr.po
@@ -1802,8 +1802,8 @@ msgstr "Produit"
 msgid "Publication date"
 msgstr "Date de publication"
 
-msgid "Publication date on this site."
-msgstr "Date de publication sur ce site."
+msgid "Publication date on this site"
+msgstr "Date de publication sur ce site"
 
 msgid "Publish"
 msgstr "Publier"

--- a/lib/AmuseWikiFarm/I18N/he.po
+++ b/lib/AmuseWikiFarm/I18N/he.po
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/he.po
+++ b/lib/AmuseWikiFarm/I18N/he.po
@@ -2654,7 +2654,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/he.po
+++ b/lib/AmuseWikiFarm/I18N/he.po
@@ -2694,7 +2694,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/he.po
+++ b/lib/AmuseWikiFarm/I18N/he.po
@@ -2817,7 +2817,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/hr.po
+++ b/lib/AmuseWikiFarm/I18N/hr.po
@@ -2880,8 +2880,8 @@ msgstr "Po broju stranica (više na početku)"
 msgid "code and monospace"
 msgstr "oblikovanje koda"
 
-msgid "comma or semicolon separated list"
-msgstr "popis odvojen zarezom"
+msgid "Comma or semicolon separated list"
+msgstr "Popis odvojen zarezom"
 
 msgid "completed"
 msgstr "gotovo"
@@ -2952,7 +2952,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "novi-uri-kao-primjer"
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr "neobavezno, ako nedostaje koristit će se polje autora"
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/hr.po
+++ b/lib/AmuseWikiFarm/I18N/hr.po
@@ -1768,7 +1768,7 @@ msgstr "Stvoreno"
 msgid "Publication date"
 msgstr "Datum objavljivanja"
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr "Datum objavljivanja na ovom sajtu"
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/hr.po
+++ b/lib/AmuseWikiFarm/I18N/hr.po
@@ -3047,7 +3047,7 @@ msgid "without description"
 msgstr "bez opisa"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 "Naslov dokumenta, u svrhu popisa. Obično se ne koristi u hrvatsko-srpskom "
 "jeziku"

--- a/lib/AmuseWikiFarm/I18N/hr.po
+++ b/lib/AmuseWikiFarm/I18N/hr.po
@@ -2920,11 +2920,11 @@ msgid "generic sectioning, good for articles"
 msgstr "općenit odjeljak, preporučen za kratke tekstove"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"ako slučajno postoji još jedan tekst istog autora i istog naslova, izaberi "
+"Ako slučajno postoji još jedan tekst istog autora i istog naslova, izaberi "
 "željeni URI koristeći polje niže, unesi autora, naslov i jedan broj, npr. "
 "moj-autor-moj-naslov-1"
 

--- a/lib/AmuseWikiFarm/I18N/id.po
+++ b/lib/AmuseWikiFarm/I18N/id.po
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/id.po
+++ b/lib/AmuseWikiFarm/I18N/id.po
@@ -2693,7 +2693,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/id.po
+++ b/lib/AmuseWikiFarm/I18N/id.po
@@ -1616,7 +1616,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/id.po
+++ b/lib/AmuseWikiFarm/I18N/id.po
@@ -2816,7 +2816,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/it.po
+++ b/lib/AmuseWikiFarm/I18N/it.po
@@ -3011,7 +3011,7 @@ msgid "generic sectioning, good for articles"
 msgstr "sezione generica, raccomandata per gli articoli"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/it.po
+++ b/lib/AmuseWikiFarm/I18N/it.po
@@ -1821,8 +1821,8 @@ msgstr "Prodotto"
 msgid "Publication date"
 msgstr "Data di pubblicazione"
 
-msgid "Publication date on this site."
-msgstr "Data di pubblicazione su questo sito."
+msgid "Publication date on this site"
+msgstr "Data di pubblicazione su questo sito"
 
 msgid "Publish"
 msgstr "Pubblica"

--- a/lib/AmuseWikiFarm/I18N/it.po
+++ b/lib/AmuseWikiFarm/I18N/it.po
@@ -2971,8 +2971,8 @@ msgstr "Per numero di pagine (da maggiore a minore)"
 msgid "code and monospace"
 msgstr "formattazione codice"
 
-msgid "comma or semicolon separated list"
-msgstr "lista separata da virgola o punto e virgola"
+msgid "Comma or semicolon separated list"
+msgstr "Lista separata da virgola o punto e virgola"
 
 msgid "completed"
 msgstr "completato"
@@ -3045,7 +3045,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "nuovo-uri-di-esempio"
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr "opzionale, se mancante verrà usata la direttiva autore"
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/it.po
+++ b/lib/AmuseWikiFarm/I18N/it.po
@@ -3142,9 +3142,9 @@ msgid "without description"
 msgstr "senza descrizione"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"potresti voler togliere gli articoli determinativi e indeterminativi\n"
+"Potresti voler togliere gli articoli determinativi e indeterminativi\n"
 "dal titolo"
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/messages.pot
+++ b/lib/AmuseWikiFarm/I18N/messages.pot
@@ -3420,7 +3420,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 #: root/src/edit/newtext.tt:28
-msgid "if by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1"
+msgid "If by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1"
 msgstr ""
 
 #: root/src/console/git_display.tt:86

--- a/lib/AmuseWikiFarm/I18N/messages.pot
+++ b/lib/AmuseWikiFarm/I18N/messages.pot
@@ -3368,7 +3368,7 @@ msgid "code and monospace"
 msgstr ""
 
 #: root/src/edit/edit.tt:670 root/src/edit/edit.tt:685 root/src/edit/newtext.tt:68 root/src/edit/newtext.tt:93
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 #: root/src/admin/jobs.tt:40 root/src/include/bulk_job.tt:2 root/src/tasks/display.tt:4
@@ -3456,7 +3456,7 @@ msgid "new-example-uri"
 msgstr ""
 
 #: root/src/edit/edit.tt:671
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 #: root/src/edit/edit.tt:433 root/src/edit/edit.tt:441 root/src/edit/edit.tt:449 root/src/edit/edit.tt:458 root/src/edit/edit.tt:464 root/src/edit/edit.tt:470 root/src/edit/edit.tt:476 root/src/edit/edit.tt:537 root/src/edit/edit.tt:538 root/src/edit/edit.tt:618

--- a/lib/AmuseWikiFarm/I18N/messages.pot
+++ b/lib/AmuseWikiFarm/I18N/messages.pot
@@ -3577,7 +3577,7 @@ msgid "without description"
 msgstr ""
 
 #: root/src/edit/newtext.tt:50
-msgid "you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+msgid "You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 #: root/src/publish/pending.tt:121

--- a/lib/AmuseWikiFarm/I18N/messages.pot
+++ b/lib/AmuseWikiFarm/I18N/messages.pot
@@ -2046,7 +2046,7 @@ msgid "Publication date"
 msgstr ""
 
 #: root/src/edit/newtext.tt:255
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 #: root/src/publish/pending.tt:46

--- a/lib/AmuseWikiFarm/I18N/mk.po
+++ b/lib/AmuseWikiFarm/I18N/mk.po
@@ -1797,8 +1797,8 @@ msgstr "Изработено"
 msgid "Publication date"
 msgstr "Датум на објавување"
 
-msgid "Publication date on this site."
-msgstr "Датум на објавување на овој сајт."
+msgid "Publication date on this site"
+msgstr "Датум на објавување на овој сајт"
 
 msgid "Publish"
 msgstr "Објави"

--- a/lib/AmuseWikiFarm/I18N/mk.po
+++ b/lib/AmuseWikiFarm/I18N/mk.po
@@ -3092,7 +3092,7 @@ msgid "without description"
 msgstr "без опис"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 "Насловот на документот, за индексирање. Обично не се користи во македонскиот "
 "јазик"

--- a/lib/AmuseWikiFarm/I18N/mk.po
+++ b/lib/AmuseWikiFarm/I18N/mk.po
@@ -2964,11 +2964,11 @@ msgid "generic sectioning, good for articles"
 msgstr "општ оддел, препорачан за кратки текстови"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"доколку случајно постои уште еден текст од истиот автор и со ист наслов, "
+"Доколку случајно постои уште еден текст од истиот автор и со ист наслов, "
 "избери го саканиот URL користејќи го полето подолу, внеси го авторот, "
 "насловот и еден број, на пр.: мој-автор-мој-наслов-1"
 

--- a/lib/AmuseWikiFarm/I18N/mk.po
+++ b/lib/AmuseWikiFarm/I18N/mk.po
@@ -2924,8 +2924,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "обликување на кодот"
 
-msgid "comma or semicolon separated list"
-msgstr "листа разделена со запирка или точка-запирка"
+msgid "Comma or semicolon separated list"
+msgstr "Листа разделена со запирка или точка-запирка"
 
 msgid "completed"
 msgstr "готово"
@@ -2996,8 +2996,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "нов-uri-како-пример"
 
-msgid "optional, defaults to the author directive"
-msgstr "незадолжително, доколку недостига ќе се користи полето автор"
+msgid "Optional, defaults to the author directive"
+msgstr "Незадолжително, доколку недостига ќе се користи полето автор"
 
 msgid "or"
 msgstr "или"

--- a/lib/AmuseWikiFarm/I18N/nl.po
+++ b/lib/AmuseWikiFarm/I18N/nl.po
@@ -1845,8 +1845,8 @@ msgstr "Gemaakt"
 msgid "Publication date"
 msgstr "Publicatiedatum"
 
-msgid "Publication date on this site."
-msgstr "Publicatiedatum op deze site."
+msgid "Publication date on this site"
+msgstr "Publicatiedatum op deze site"
 
 msgid "Publish"
 msgstr "Publiceer"

--- a/lib/AmuseWikiFarm/I18N/nl.po
+++ b/lib/AmuseWikiFarm/I18N/nl.po
@@ -3178,9 +3178,9 @@ msgid "without description"
 msgstr "zonder beschrijving"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"je zou wellicht de \"Een\", \"De\" etc. vooraan de titel willen verwijderen"
+"Je zou wellicht de \"Een\", \"De\" etc. vooraan de titel willen verwijderen"
 
 msgid ""
 "“Stale editing” means that the revision was abandoned\n"

--- a/lib/AmuseWikiFarm/I18N/nl.po
+++ b/lib/AmuseWikiFarm/I18N/nl.po
@@ -3008,8 +3008,8 @@ msgstr "Op aantal pagina's, aflopend"
 msgid "code and monospace"
 msgstr "code en niet-proportioneel (monospace)"
 
-msgid "comma or semicolon separated list"
-msgstr "komma of puntkomma gescheiden lijst"
+msgid "Comma or semicolon separated list"
+msgstr "Komma of puntkomma gescheiden lijst"
 
 msgid "completed"
 msgstr "voltooid"
@@ -3082,8 +3082,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "nieuwe-voorbeeld-uri"
 
-msgid "optional, defaults to the author directive"
-msgstr "optioneel, gebruikt standaard de auteur instructie"
+msgid "Optional, defaults to the author directive"
+msgstr "Optioneel, gebruikt standaard de auteur instructie"
 
 msgid "or"
 msgstr "of"

--- a/lib/AmuseWikiFarm/I18N/nl.po
+++ b/lib/AmuseWikiFarm/I18N/nl.po
@@ -3048,11 +3048,11 @@ msgid "generic sectioning, good for articles"
 msgstr "generieke indeling, goed voor artikelen"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"als door toeval een andere tekst met dezelfde auteur en titel bestaat, kies "
+"Als door toeval een andere tekst met dezelfde auteur en titel bestaat, kies "
 "dan de gewenste URI door het veld hieronder te gebruiken en auteur, titel en "
 "een getal in te voeren, bijvoorbeeld mijn-auteur-mijn-titel-1"
 

--- a/lib/AmuseWikiFarm/I18N/pl.po
+++ b/lib/AmuseWikiFarm/I18N/pl.po
@@ -2695,7 +2695,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/pl.po
+++ b/lib/AmuseWikiFarm/I18N/pl.po
@@ -2818,7 +2818,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/pl.po
+++ b/lib/AmuseWikiFarm/I18N/pl.po
@@ -2655,7 +2655,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2724,7 +2724,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/pl.po
+++ b/lib/AmuseWikiFarm/I18N/pl.po
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/pt.po
+++ b/lib/AmuseWikiFarm/I18N/pt.po
@@ -2990,11 +2990,11 @@ msgid "generic sectioning, good for articles"
 msgstr "seccionamento genérico, bom para artigos"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"se por acaso outro texto com o mesmo autor e título existe, escolha a URI "
+"Se por acaso outro texto com o mesmo autor e título existe, escolha a URI "
 "desejada usando o campo abaixo inserindo autor, título e um número, por "
 "exemplo meu-autor-meu-titulo-1"
 

--- a/lib/AmuseWikiFarm/I18N/pt.po
+++ b/lib/AmuseWikiFarm/I18N/pt.po
@@ -3120,9 +3120,9 @@ msgid "without description"
 msgstr "sem descrição"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"você pode querer remover o artigo do início do título (O, A, Uma, Um, etc)"
+"Você pode querer remover o artigo do início do título (O, A, Uma, Um, etc)"
 
 msgid ""
 "“Stale editing” means that the revision was abandoned\n"

--- a/lib/AmuseWikiFarm/I18N/pt.po
+++ b/lib/AmuseWikiFarm/I18N/pt.po
@@ -2950,8 +2950,8 @@ msgstr "Por número de páginas, descendente"
 msgid "code and monospace"
 msgstr "código e monoespaçamento"
 
-msgid "comma or semicolon separated list"
-msgstr "lista separada por vírgula ou ponto-e-vírgula"
+msgid "Comma or semicolon separated list"
+msgstr "Lista separada por vírgula ou ponto-e-vírgula"
 
 msgid "completed"
 msgstr "completado"
@@ -3024,8 +3024,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr "nova-uri-de-exemplo"
 
-msgid "optional, defaults to the author directive"
-msgstr "opcional, o padrão é a diretiva autor"
+msgid "Optional, defaults to the author directive"
+msgstr "Opcional, o padrão é a diretiva autor"
 
 msgid "or"
 msgstr "ou"

--- a/lib/AmuseWikiFarm/I18N/pt.po
+++ b/lib/AmuseWikiFarm/I18N/pt.po
@@ -1806,7 +1806,7 @@ msgstr "Produzido"
 msgid "Publication date"
 msgstr "Data de publicação"
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr "Publicação e data neste site"
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/ru.po
+++ b/lib/AmuseWikiFarm/I18N/ru.po
@@ -3084,8 +3084,8 @@ msgid "without description"
 msgstr "без описания"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
-msgstr "возможно вы захотите отделить «О», «Об» и др. от названия"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
+msgstr "Возможно вы захотите отделить «О», «Об» и др. от названия"
 
 msgid ""
 "“Stale editing” means that the revision was abandoned\n"

--- a/lib/AmuseWikiFarm/I18N/ru.po
+++ b/lib/AmuseWikiFarm/I18N/ru.po
@@ -2954,11 +2954,11 @@ msgid "generic sectioning, good for articles"
 msgstr "общее разделение на разделы, хорошо для статей"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"если другой текст с этими же автором и названием существует, введите нужный "
+"Если другой текст с этими же автором и названием существует, введите нужный "
 "URI, включающий автора, название и номер, например moi-avtor-moe-nazvanie-1"
 
 msgid "if the repository is exported"

--- a/lib/AmuseWikiFarm/I18N/ru.po
+++ b/lib/AmuseWikiFarm/I18N/ru.po
@@ -2914,8 +2914,8 @@ msgstr "По убыванию числа страниц"
 msgid "code and monospace"
 msgstr "код и моноширинный"
 
-msgid "comma or semicolon separated list"
-msgstr "список, разделённый запятой или точкой с запятой"
+msgid "Comma or semicolon separated list"
+msgstr "Список, разделённый запятой или точкой с запятой"
 
 msgid "completed"
 msgstr "завершено"
@@ -2987,8 +2987,8 @@ msgstr "минуты"
 msgid "new-example-uri"
 msgstr "пример-uri"
 
-msgid "optional, defaults to the author directive"
-msgstr "опционально (по указанию автора)"
+msgid "Optional, defaults to the author directive"
+msgstr "Опционально (по указанию автора)"
 
 msgid "or"
 msgstr "или"

--- a/lib/AmuseWikiFarm/I18N/ru.po
+++ b/lib/AmuseWikiFarm/I18N/ru.po
@@ -1781,8 +1781,8 @@ msgstr "Изготовлено"
 msgid "Publication date"
 msgstr "Дата публикации"
 
-msgid "Publication date on this site."
-msgstr "Дата публикации на этом сайте."
+msgid "Publication date on this site"
+msgstr "Дата публикации на этом сайте"
 
 msgid "Publish"
 msgstr "Опубликовать"

--- a/lib/AmuseWikiFarm/I18N/sq.po
+++ b/lib/AmuseWikiFarm/I18N/sq.po
@@ -2895,8 +2895,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "Kodi dhe monospace"
 
-msgid "comma or semicolon separated list"
-msgstr "listë e ndarë me presje ose pikëpresje"
+msgid "Comma or semicolon separated list"
+msgstr "Listë e ndarë me presje ose pikëpresje"
 
 msgid "completed"
 msgstr "i kompletuar"
@@ -2969,8 +2969,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
-msgstr "opcionale, e parazgjedhur direktiva e autorit"
+msgid "Optional, defaults to the author directive"
+msgstr "Opcionale, e parazgjedhur direktiva e autorit"
 
 msgid "or"
 msgstr "ose"

--- a/lib/AmuseWikiFarm/I18N/sq.po
+++ b/lib/AmuseWikiFarm/I18N/sq.po
@@ -3063,7 +3063,7 @@ msgid "without description"
 msgstr "pa përshkrim"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 "Nëse dëshironi, ju mund të largoni parafjalët, fjalët lidhëse e të tjera, "
 "nga titulli."

--- a/lib/AmuseWikiFarm/I18N/sq.po
+++ b/lib/AmuseWikiFarm/I18N/sq.po
@@ -1773,7 +1773,7 @@ msgstr "Krijuar"
 msgid "Publication date"
 msgstr "Data e publikimit"
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr "Data e publikimit në këtë faqe"
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/sq.po
+++ b/lib/AmuseWikiFarm/I18N/sq.po
@@ -2935,11 +2935,11 @@ msgid "generic sectioning, good for articles"
 msgstr "seksionim gjenerik, e mirë për artikuj"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"nëse ekziston një tekst tjetër, me autor dhe titull të njejtë, zgjedhe URI-"
+"Nëse ekziston një tekst tjetër, me autor dhe titull të njejtë, zgjedhe URI-"
 "në e dëshiruar duke plotësuar fushën më poshtë me autorin, titullin dhe "
 "numrin, p.sh autori-im-titulli-im-1"
 

--- a/lib/AmuseWikiFarm/I18N/sr.po
+++ b/lib/AmuseWikiFarm/I18N/sr.po
@@ -2695,7 +2695,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/sr.po
+++ b/lib/AmuseWikiFarm/I18N/sr.po
@@ -2818,7 +2818,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/sr.po
+++ b/lib/AmuseWikiFarm/I18N/sr.po
@@ -2655,7 +2655,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2724,7 +2724,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/sr.po
+++ b/lib/AmuseWikiFarm/I18N/sr.po
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/sv.po
+++ b/lib/AmuseWikiFarm/I18N/sv.po
@@ -2919,9 +2919,9 @@ msgid "without description"
 msgstr "utan beskrivning"
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
-"du bör överväga att ta bort det inledande \"En\", \"Ett\", \"Den\" och så "
+"Du bör överväga att ta bort det inledande \"En\", \"Ett\", \"Den\" och så "
 "vidare från titeln"
 
 msgid ""

--- a/lib/AmuseWikiFarm/I18N/sv.po
+++ b/lib/AmuseWikiFarm/I18N/sv.po
@@ -2793,11 +2793,11 @@ msgid "generic sectioning, good for articles"
 msgstr "generisk uppdelning, bra för artiklar"
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""
-"om det av en händelse skulle finnas en annan text med samma författare och "
+"Om det av en händelse skulle finnas en annan text med samma författare och "
 "titel, välj den önskade URI genom att fylla i fältet nedan med författare, "
 "titel och nummer, t.ex. min-förf-min-titel-1"
 

--- a/lib/AmuseWikiFarm/I18N/sv.po
+++ b/lib/AmuseWikiFarm/I18N/sv.po
@@ -1682,8 +1682,8 @@ msgstr "Producerad"
 msgid "Publication date"
 msgstr "Publikationsdatum"
 
-msgid "Publication date on this site."
-msgstr "Publikationsdatum på denna sida."
+msgid "Publication date on this site"
+msgstr "Publikationsdatum på denna sida"
 
 msgid "Publish"
 msgstr "Publicera"

--- a/lib/AmuseWikiFarm/I18N/sv.po
+++ b/lib/AmuseWikiFarm/I18N/sv.po
@@ -2753,8 +2753,8 @@ msgstr ""
 msgid "code and monospace"
 msgstr "kod och monospace"
 
-msgid "comma or semicolon separated list"
-msgstr "lista separerad med komma eller semikolon"
+msgid "Comma or semicolon separated list"
+msgstr "Lista separerad med komma eller semikolon"
 
 msgid "completed"
 msgstr "slutförd"
@@ -2825,8 +2825,8 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
-msgstr "valfri, förvalda värden till författaranvisningen"
+msgid "Optional, defaults to the author directive"
+msgstr "Valfri, förvalda värden till författaranvisningen"
 
 msgid "or"
 msgstr "eller"

--- a/lib/AmuseWikiFarm/I18N/tr.po
+++ b/lib/AmuseWikiFarm/I18N/tr.po
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "Publication date"
 msgstr ""
 
-msgid "Publication date on this site."
+msgid "Publication date on this site"
 msgstr ""
 
 msgid "Publish"

--- a/lib/AmuseWikiFarm/I18N/tr.po
+++ b/lib/AmuseWikiFarm/I18N/tr.po
@@ -2654,7 +2654,7 @@ msgstr ""
 msgid "code and monospace"
 msgstr ""
 
-msgid "comma or semicolon separated list"
+msgid "Comma or semicolon separated list"
 msgstr ""
 
 msgid "completed"
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "new-example-uri"
 msgstr ""
 
-msgid "optional, defaults to the author directive"
+msgid "Optional, defaults to the author directive"
 msgstr ""
 
 msgid "or"

--- a/lib/AmuseWikiFarm/I18N/tr.po
+++ b/lib/AmuseWikiFarm/I18N/tr.po
@@ -2694,7 +2694,7 @@ msgid "generic sectioning, good for articles"
 msgstr ""
 
 msgid ""
-"if by chance another text with the same author and title exists, choose the "
+"If by chance another text with the same author and title exists, choose the "
 "desired URI using the field below inserting author, title and a number, e.g. "
 "my-author-my-title-1"
 msgstr ""

--- a/lib/AmuseWikiFarm/I18N/tr.po
+++ b/lib/AmuseWikiFarm/I18N/tr.po
@@ -2817,7 +2817,7 @@ msgid "without description"
 msgstr ""
 
 msgid ""
-"you may want to strip the leading “A”, “An”, “The”, and so on from the title"
+"You may want to strip the leading “A”, “An”, “The”, and so on from the title"
 msgstr ""
 
 msgid ""

--- a/root/src/edit/edit.tt
+++ b/root/src/edit/edit.tt
@@ -665,10 +665,10 @@ How smart a lash that speech doth giue my Conscience?
         <li>
           <code>
 	        #SORTauthors [% loc('First Author, Second Author') %]
-          </code>
-          [% loc('Authors for indexing') %]:
-          [% loc('comma or semicolon separated list') %]
-          ([% loc('optional, defaults to the author directive') %]).
+          </code><br/>
+          [% loc('Authors for indexing') %].
+          [% loc('Comma or semicolon separated list') %].
+          [% loc('Optional, defaults to the author directive') %].
         </li>
         <li>
           <code>#LISTtitle [% loc('Nice title') %]</code> <br /> [%
@@ -682,7 +682,7 @@ How smart a lash that speech doth giue my Conscience?
         </li>
         <li>
           <code>#SORTtopics [% loc('topic') %] 1, [% loc('topic') %] 2, [% loc('topic') %] 3</code><br />
-          [% loc('Topics') %]: [% loc('comma or semicolon separated list') %].
+          [% loc('Topics') %]. [% loc('Comma or semicolon separated list') %].
         </li>
         <li>
           <code>#date 2012</code><br />

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -86,7 +86,7 @@
         </label>
       </div>
       [% END %]
-    </p>
+    </div>
     [% ELSE %]
     <p>
       <label for="SORTtopics">[% loc('Topics') %]</label>:

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -254,18 +254,17 @@
   </p>
   [% END %]
   </div>
-  <div>
-    <br />
-    <p>
-      <label for="pubdate">[% loc('Publication date on this site.') %]
+  <div class="form-group">
+    <label for="pubdate">[% loc('Publication date on this site') %]</label>
+    <input class="form-control" id="pubdate"
+           name="pubdate" />
+    <p class="help-block">
       [% loc('Leave it blank if you want it published right away.') %]
-      </label><br />
       [% loc('Set a date in the future if you want it deferred.') %]
       [% loc('Time is optional.') %]
       [% loc('Format: yyyy-mm-dd hh:mm, e.g.') %]
-      <code>2014-10-19 08:30</code><br />
-      <input class="form-control" id="pubdate"
-             name="pubdate" />
+      <code>2014-10-19 08:30</code>
+    </p>
   </div>
   <div class="center">
     <p>

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -48,10 +48,12 @@
 
   <div class="form-group">
     <label for="LISTtitle">[% loc('Title for sorting') %]</label>
-    ([% loc('you may want to strip the leading “A”, “An”, “The”, and so on from the title') %]):
     <input class="form-control" type="text" name="LISTtitle" id="LISTtitle"
            maxlength="250" size="30"
            value="[% processed_params.LISTtitle | html %]" />
+    <p class="help-block">
+      [% loc('You may want to strip the leading “A”, “An”, “The”, and so on from the title') %].
+    </p>
   </div>
 
 

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -59,7 +59,7 @@
 
   <div class="form-group">
     <label for="author">[% loc('Author') %]</label>
-    ([% loc('for display') %]):
+    ([% loc('for display') %])
     <input class="form-control amwautocomplete"
            type="text" name="author" id="author"
                maxlength="250"

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -125,11 +125,13 @@
 
   <div class="form-group"><label for="source">[% loc('Source') %]</label>
 
-    ([% loc('For texts from the internet use') %]:
-     [% loc('Retrieved on DATE from URL') %]).
 
     <input class="form-control" id="source" size="50" maxlength="250"
                name="source" value="[% processed_params.source | html %]" />
+    <p class="help-block">
+      [% loc('For texts from the internet use') %]:
+      [% loc('Retrieved on DATE from URL') %].
+    </p>
   </div>
   [% END %]
   <div class="form-group">

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -7,236 +7,235 @@
 
 <form id="ckform" method="post"
       enctype="multipart/form-data">
+
+  [% IF pop_uri_field_to_the_top %]
+  <div id="choose-uri" class="form-group">
+    <label class="mandatory" for="uri">[% loc('Desired URI') %]
+      ([% loc('Please set the URI you desire. Author (if present),
+      title and eventually a number if the URI already exists is
+      usually a good choice') %]).
+    </label>
+    <br>
+    <input class="form-control" type="text" name="uri" id="uri" size="50"
+           value="[% processed_params.uri | html %]"/>
+  </div>
+  [% END %]
   <div class="form-group">
+    <label for="title" class="mandatory">[% loc('Title') %]
+      ([% loc('mandatory') %])
+    </label>:
+    [% loc('if by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1') %]
+    <a href="#choose-uri">
+      <span class="fa fa-share"></span>
+    </a>
+    <input class="form-control" type="text" name="title"
+           maxlength="250" id="title"
+           size="30"
+           value="[% processed_params.title | html %]" />
+  </div>
 
-    [% IF pop_uri_field_to_the_top %]
-    <p id="choose-uri">
-      <label class="mandatory" for="uri">[% loc('Desired URI') %]
-        ([% loc('Please set the URI you desire. Author (if present),
-        title and eventually a number if the URI already exists is
-        usually a good choice') %]).
-      </label>
-      <br>
-      <input class="form-control" type="text" name="uri" id="uri" size="50"
-             value="[% processed_params.uri | html %]"/>
-    </p>
-    [% END %]
-    <p>
-      <label for="title" class="mandatory">[% loc('Title') %]
-        ([% loc('mandatory') %])
-      </label>:
-      [% loc('if by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1') %]
-      <a href="#choose-uri">
-        <span class="fa fa-share"></span>
-      </a>
-      <input class="form-control" type="text" name="title"
-             maxlength="250" id="title"
-             size="30"
-             value="[% processed_params.title | html %]" />
-    </p>
+  <div class="form-group">
+    <label for="subtitle">[% loc('Subtitle') %]</label>:
+    <input class="form-control" type="text" name="subtitle" id="subtitle"
+           maxlength="250"
+           size="30"
+           value="[% processed_params.subtitle | html %]" />
+  </div>
 
-    <p>
-      <label for="subtitle">[% loc('Subtitle') %]</label>:
-      <input class="form-control" type="text" name="subtitle" id="subtitle"
-             maxlength="250"
-             size="30"
-             value="[% processed_params.subtitle | html %]" />
-    </p>
+  [% IF f_class == 'text' %]
 
-    [% IF f_class == 'text' %]
-
-    <p>
-      <label for="LISTtitle">[% loc('Title for sorting') %]</label>
-      ([% loc('you may want to strip the leading “A”, “An”, “The”, and so on from the title') %]):
-      <input class="form-control" type="text" name="LISTtitle" id="LISTtitle"
-             maxlength="250" size="30"
-             value="[% processed_params.LISTtitle | html %]" />
-    </p>
+  <div class="form-group">
+    <label for="LISTtitle">[% loc('Title for sorting') %]</label>
+    ([% loc('you may want to strip the leading “A”, “An”, “The”, and so on from the title') %]):
+    <input class="form-control" type="text" name="LISTtitle" id="LISTtitle"
+           maxlength="250" size="30"
+           value="[% processed_params.LISTtitle | html %]" />
+  </div>
 
 
-    <p>
-      <label for="author">[% loc('Author') %]</label>
-      ([% loc('for display') %]):
-      <input class="form-control amwautocomplete"
-             type="text" name="author" id="author"
-                 maxlength="250"
-                 value="[% processed_params.author | html %]" />
-    </p>
+  <div class="form-group">
+    <label for="author">[% loc('Author') %]</label>
+    ([% loc('for display') %]):
+    <input class="form-control amwautocomplete"
+           type="text" name="author" id="author"
+               maxlength="250"
+               value="[% processed_params.author | html %]" />
+  </div>
 
-    <p>
-      <label for="SORTauthors">[% loc('Authors for indexing') %]</label>,
-      [% loc('comma or semicolon separated list') %]:
-      <input class="form-control amwautocomplete" id="SORTauthors"
-             maxlength="250"
-             name="SORTauthors"
-             value="[% processed_params.SORTauthors | html %]" />
-    </p>
+  <div class="form-group">
+    <label for="SORTauthors">[% loc('Authors for indexing') %]</label>,
+    [% loc('comma or semicolon separated list') %]:
+    <input class="form-control amwautocomplete" id="SORTauthors"
+           maxlength="250"
+           name="SORTauthors"
+           value="[% processed_params.SORTauthors | html %]" />
+  </div>
 
-    [% IF site.fixed_category_list %]
-    <div id="fixed-category-choose">
-      <strong>[% loc('Categories') %]</strong>
-      [% FOREACH cat IN site.list_fixed_categories %]
-      <div class="checkbox">
-        <label>
-          [% fixed_cat_name = "fixed_cat_" _ cat %]
-          <input type="checkbox"
-                 [% IF c.req.params.$fixed_cat_name %]checked="checked"[% END %]
-                 name="[% fixed_cat_name %]" value="[% cat %]"/>
-          [% loc(cat) %]
-        </label>
-      </div>
-      [% END %]
-    </div>
-    [% ELSE %]
-    <p>
-      <label for="SORTtopics">[% loc('Topics') %]</label>:
-      [% loc('comma or semicolon separated list') %]
-      <br />
-      <input class="form-control amwautocomplete" id="SORTtopics"
-             size="50"
-             maxlength="250"
-             name="SORTtopics"
-             value="[% processed_params.SORTtopics | html %]" />
-    </p>
-    [% END %]
-
-    [% IF site.multilanguage %]
-    <p>
-      <label for="text-uid">[% loc('Unique ID for the text') %]</label>
-      <input class="form-control" name="uid" id="text-uid" type="text"
-             value="[% processed_params.uid | html %]" />
-    </p>
-    [% END %]
-
-    <p>
-      <label for="date">[% loc('Date of the original publication') %]</label>
-      <input class="form-control" id="date"
-             size="50"
-             maxlength="250"
-             name="date"
-             value="[% processed_params.date | html %]" />
-    </p>
-
-    <p><label for="source">[% loc('Source') %]</label>
-
-      ([% loc('For texts from the internet use') %]:
-       [% loc('Retrieved on DATE from URL') %]).
-
-      <input class="form-control" id="source" size="50" maxlength="250"
-                 name="source" value="[% processed_params.source | html %]" />
-    </p>
-    [% END %]
-    <p>
-      [% SET current_language = processed_params.lang || current_locale_code %]
-      <label for="lang">[% loc('Language') %]</label>
-      <select name="lang" id="lang" class="form-control">
-
-      [% known_langs = site.known_langs %]
-      [% FOREACH lang IN known_langs.keys.sort %]
-      <option [% IF current_language == lang %]selected="selected"[% END %]
-              value="[% lang %]">
-        [% known_langs.$lang %]
-      </option>
-      [% END %]
-    </select>
-    </p>
-
-    [% IF site.sl_pdf %]
+  [% IF site.fixed_category_list %]
+  <div id="fixed-category-choose" class="form-group">
+    <strong>[% loc('Categories') %]</strong>
+    [% FOREACH cat IN site.list_fixed_categories %]
     <div class="checkbox">
       <label>
+        [% fixed_cat_name = "fixed_cat_" _ cat %]
         <input type="checkbox"
-               [% IF c.req.params.slides %]checked="checked"[% END %]
-               name="slides" value="yes"/>
-        <strong>[% loc('Produce slides.') %]</strong> [% loc('Every
-        section will generate a slide. You need to do proper
-        sectioning for this to work.') %]
+               [% IF c.req.params.$fixed_cat_name %]checked="checked"[% END %]
+               name="[% fixed_cat_name %]" value="[% cat %]"/>
+        [% loc(cat) %]
       </label>
     </div>
     [% END %]
+  </div>
+  [% ELSE %]
+  <div class="form-group">
+    <label for="SORTtopics">[% loc('Topics') %]</label>:
+    [% loc('comma or semicolon separated list') %]
+    <br />
+    <input class="form-control amwautocomplete" id="SORTtopics"
+           size="50"
+           maxlength="250"
+           name="SORTtopics"
+           value="[% processed_params.SORTtopics | html %]" />
+  </div>
+  [% END %]
 
-    <h3>[% loc('Main text') %]</h3>
-    <div>
-        [% loc('Please note that you may want to paste from a
+  [% IF site.multilanguage %]
+  <div class="form-group">
+    <label for="text-uid">[% loc('Unique ID for the text') %]</label>
+    <input class="form-control" name="uid" id="text-uid" type="text"
+           value="[% processed_params.uid | html %]" />
+  </div>
+  [% END %]
+
+  <div class="form-group">
+    <label for="date">[% loc('Date of the original publication') %]</label>
+    <input class="form-control" id="date"
+           size="50"
+           maxlength="250"
+           name="date"
+           value="[% processed_params.date | html %]" />
+  </div>
+
+  <div class="form-group"><label for="source">[% loc('Source') %]</label>
+
+    ([% loc('For texts from the internet use') %]:
+     [% loc('Retrieved on DATE from URL') %]).
+
+    <input class="form-control" id="source" size="50" maxlength="250"
+               name="source" value="[% processed_params.source | html %]" />
+  </div>
+  [% END %]
+  <div class="form-group">
+    [% SET current_language = processed_params.lang || current_locale_code %]
+    <label for="lang">[% loc('Language') %]</label>
+    <select name="lang" id="lang" class="form-control">
+
+    [% known_langs = site.known_langs %]
+    [% FOREACH lang IN known_langs.keys.sort %]
+    <option [% IF current_language == lang %]selected="selected"[% END %]
+            value="[% lang %]">
+      [% known_langs.$lang %]
+    </option>
+    [% END %]
+  </select>
+  </div>
+
+  [% IF site.sl_pdf %]
+  <div class="checkbox">
+    <label>
+      <input type="checkbox"
+             [% IF c.req.params.slides %]checked="checked"[% END %]
+             name="slides" value="yes"/>
+      <strong>[% loc('Produce slides.') %]</strong> [% loc('Every
+      section will generate a slide. You need to do proper
+      sectioning for this to work.') %]
+    </label>
+  </div>
+  [% END %]
+
+  <h3>[% loc('Main text') %]</h3>
+  <div>
+      [% loc('Please note that you may want to paste from a
         Word/OpenOffice/LibreOffice/HTML document using the “paste
         from word” button. This is supposed to preserve the markup.') %]
 
-        <br />
-
-        [% loc('This is a WYSIWYG editor. If you prefer to use
-        the wiki-like syntax leave it as is, fill the required fields
-        above and postpone the editing to the next step.') %]
-        <br />
-
-        [% loc('Image uploading may be done on the next step, when you can
-        review and preview the upload.') %]
-
-        <br />
-        [% loc('Keep in mind that unusually
-        complex formatting will be stripped. Is it possible to add
-        tables and images only on the next step.') %]
-    </div>
-    <div>&nbsp;</div>
-    <div>
-      <textarea id="textbody" name="textbody" cols="80"
-                rows="20">[%- processed_params.textbody | html -%]</textarea>
-    </div>
-    <div>&nbsp;</div>
-    <div>
-      <p>
-        <strong>[% loc('Or provide an HTML file to upload') %]</strong>
-      </p>
-      <p>
-        [% loc('If you have a file in .doc or .odt, you can easily convert it saving it as HTML') %]
-      </p>
-      <p>
-        <input id="texthtmlfile" name="texthtmlfile" type="file" />
-      </p>
-    </div>
-
-    [% IF f_class == 'text' %]
-    <h3>[% loc('Notes') %]</h3>
-    <div>
-      [% loc('Put additional information here (original
-	  title, translators, credits, etc). Footnotes go in the
-	  body.') %]
-    </div>
-    <div>&nbsp;</div>
-    <div>
-      <textarea id="notes" name="notes" cols="80"
-                rows="5">[%- processed_params.notes | html %]</textarea>
-    </div>
-    [% END %]
-
-    [% IF blog_style %]
-    [% IF f_class == 'text' %]
-    <h3>[% loc('Teaser') %]</h3>
-    <div>
-      [% loc('The text to show on the homepage preview') %]
-    </div>
-    [% IF site.automatic_teaser %]
-    <div>
-      <span class="fa fa-warning"></span>
-      <strong>[% loc('Leave this empty to have it automatically generated') %]</strong>
-    </div>
-    [% END %]
-    <div>&nbsp;</div>
-    <div>
-      <textarea id="teaser" name="teaser" cols="80"
-                rows="10">[%- processed_params.teaser | html %]</textarea>
-    </div>
-    [% END %]
-    [% END %]
-
-    <div>
-      <br /><br />
-    [% UNLESS pop_uri_field_to_the_top %]
-    <p id="choose-uri">
-      <label for="uri">[% loc('Desired URI') %]
-      ([% loc('automatically generated if not present, using author and title') %])
-      </label>
       <br />
 
-      [% loc("An URI is a string which uniquely identifies the text
+      [% loc('This is a WYSIWYG editor. If you prefer to use
+        the wiki-like syntax leave it as is, fill the required fields
+        above and postpone the editing to the next step.') %]
+      <br />
+
+      [% loc('Image uploading may be done on the next step, when you can
+        review and preview the upload.') %]
+
+      <br />
+      [% loc('Keep in mind that unusually
+        complex formatting will be stripped. Is it possible to add
+        tables and images only on the next step.') %]
+  </div>
+  <div>&nbsp;</div>
+  <div>
+    <textarea id="textbody" name="textbody" cols="80"
+              rows="20">[%- processed_params.textbody | html -%]</textarea>
+  </div>
+  <div>&nbsp;</div>
+  <div>
+    <p>
+      <strong>[% loc('Or provide an HTML file to upload') %]</strong>
+    </p>
+    <p>
+      [% loc('If you have a file in .doc or .odt, you can easily convert it saving it as HTML') %]
+    </p>
+    <p>
+      <input id="texthtmlfile" name="texthtmlfile" type="file" />
+    </p>
+  </div>
+
+  [% IF f_class == 'text' %]
+  <h3>[% loc('Notes') %]</h3>
+  <div>
+    [% loc('Put additional information here (original
+	  title, translators, credits, etc). Footnotes go in the
+	  body.') %]
+  </div>
+  <div>&nbsp;</div>
+  <div>
+    <textarea id="notes" name="notes" cols="80"
+              rows="5">[%- processed_params.notes | html %]</textarea>
+  </div>
+  [% END %]
+
+  [% IF blog_style %]
+  [% IF f_class == 'text' %]
+  <h3>[% loc('Teaser') %]</h3>
+  <div>
+    [% loc('The text to show on the homepage preview') %]
+  </div>
+  [% IF site.automatic_teaser %]
+  <div>
+    <span class="fa fa-warning"></span>
+    <strong>[% loc('Leave this empty to have it automatically generated') %]</strong>
+  </div>
+  [% END %]
+  <div>&nbsp;</div>
+  <div>
+    <textarea id="teaser" name="teaser" cols="80"
+              rows="10">[%- processed_params.teaser | html %]</textarea>
+  </div>
+  [% END %]
+  [% END %]
+
+  <div>
+    <br /><br />
+  [% UNLESS pop_uri_field_to_the_top %]
+  <p id="choose-uri">
+    <label for="uri">[% loc('Desired URI') %]
+    ([% loc('automatically generated if not present, using author and title') %])
+    </label>
+    <br />
+
+    [% loc("An URI is a string which uniquely identifies the text
       in the archive. In theory, it could be anything, but if you want
       to set it yourself, please stick with the convention: author
       name, title, language, eventual number for disambiguation, e.g.
@@ -244,50 +243,49 @@
       not needed") %]
 
 
-      <input class="form-control" type="text" name="uri" id="uri" size="50"
-             value="[% processed_params.uri | html %]"/>
-    </p>
-    [% END %]
-    </div>
-    <div>
-      <br />
-      <p>
-        <label for="pubdate">[% loc('Publication date on this site.') %]
-        [% loc('Leave it blank if you want it published right away.') %]
-        </label><br />
-        [% loc('Set a date in the future if you want it deferred.') %]
-        [% loc('Time is optional.') %]
-        [% loc('Format: yyyy-mm-dd hh:mm, e.g.') %]
-        <code>2014-10-19 08:30</code><br />
-        <input class="form-control" id="pubdate"
-               name="pubdate" />
-    </div>
-    <div class="center">
-      <p>
-        [% loc('Keep in mind that I’m cleaning the text and give it
+    <input class="form-control" type="text" name="uri" id="uri" size="50"
+           value="[% processed_params.uri | html %]"/>
+  </p>
+  [% END %]
+  </div>
+  <div>
+    <br />
+    <p>
+      <label for="pubdate">[% loc('Publication date on this site.') %]
+      [% loc('Leave it blank if you want it published right away.') %]
+      </label><br />
+      [% loc('Set a date in the future if you want it deferred.') %]
+      [% loc('Time is optional.') %]
+      [% loc('Format: yyyy-mm-dd hh:mm, e.g.') %]
+      <code>2014-10-19 08:30</code><br />
+      <input class="form-control" id="pubdate"
+             name="pubdate" />
+  </div>
+  <div class="center">
+    <p>
+      [% loc('Keep in mind that I’m cleaning the text and give it
         back to you in the markup used on this site. It’s up to you to
         check it and finally upload it. Some rarely used markup will
         be lost in the process. Please check the preview on the next
         step, where you can also insert images.') %]
-      </p>
-      <button type="submit" class="btn btn-default"
-                  name="go" value="go">
-        [% loc('Create') %]
-      </button>
-    </div>
-    <script type="text/javascript">
-      $(document).ready(function(){
-        $("#ckform").validate({
-            rules: {
-                title: "required"
-            },
-            messages: {
-                title: "[% loc('This field is required') %]"
-            }
-        });
+    </p>
+    <button type="submit" class="btn btn-default"
+            name="go" value="go">
+      [% loc('Create') %]
+    </button>
+  </div>
+  <script type="text/javascript">
+    $(document).ready(function(){
+      $("#ckform").validate({
+          rules: {
+              title: "required"
+          },
+          messages: {
+              title: "[% loc('This field is required') %]"
+          }
       });
-    </script>
-</div>
+    });
+  </script>
 </form>
 
 <script type="text/javascript">

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -190,15 +190,11 @@
               rows="20">[%- processed_params.textbody | html -%]</textarea>
   </div>
   <div>&nbsp;</div>
-  <div>
-    <p>
-      <strong>[% loc('Or provide an HTML file to upload') %]</strong>
-    </p>
-    <p>
+  <div class="form-group">
+    <label for="texthtmlfile">[% loc('Or provide an HTML file to upload') %]</label>
+    <input id="texthtmlfile" name="texthtmlfile" type="file" />
+    <p class="help-block">
       [% loc('If you have a file in .doc or .odt, you can easily convert it saving it as HTML') %]
-    </p>
-    <p>
-      <input id="texthtmlfile" name="texthtmlfile" type="file" />
     </p>
   </div>
 

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -30,27 +30,27 @@
         <span class="fa fa-share"></span>
       </a>
       <input class="form-control" type="text" name="title"
-	     maxlength="250" id="title"
-	     size="30"
-	     value="[% processed_params.title | html %]" />
+             maxlength="250" id="title"
+             size="30"
+             value="[% processed_params.title | html %]" />
     </p>
 
     <p>
       <label for="subtitle">[% loc('Subtitle') %]</label>:
       <input class="form-control" type="text" name="subtitle" id="subtitle"
-	     maxlength="250"
-	     size="30"
-	     value="[% processed_params.subtitle | html %]" />
+             maxlength="250"
+             size="30"
+             value="[% processed_params.subtitle | html %]" />
     </p>
-    
+
     [% IF f_class == 'text' %]
 
     <p>
       <label for="LISTtitle">[% loc('Title for sorting') %]</label>
       ([% loc('you may want to strip the leading “A”, “An”, “The”, and so on from the title') %]):
       <input class="form-control" type="text" name="LISTtitle" id="LISTtitle"
-	     maxlength="250" size="30"
-	     value="[% processed_params.LISTtitle | html %]" />
+             maxlength="250" size="30"
+             value="[% processed_params.LISTtitle | html %]" />
     </p>
 
 
@@ -59,17 +59,17 @@
       ([% loc('for display') %]):
       <input class="form-control amwautocomplete"
              type="text" name="author" id="author"
-	         maxlength="250"
-	         value="[% processed_params.author | html %]" />
+                 maxlength="250"
+                 value="[% processed_params.author | html %]" />
     </p>
 
     <p>
       <label for="SORTauthors">[% loc('Authors for indexing') %]</label>,
       [% loc('comma or semicolon separated list') %]:
       <input class="form-control amwautocomplete" id="SORTauthors"
-	     maxlength="250"
-	     name="SORTauthors"
-	     value="[% processed_params.SORTauthors | html %]" />
+             maxlength="250"
+             name="SORTauthors"
+             value="[% processed_params.SORTauthors | html %]" />
     </p>
 
     [% IF site.fixed_category_list %]
@@ -93,10 +93,10 @@
       [% loc('comma or semicolon separated list') %]
       <br />
       <input class="form-control amwautocomplete" id="SORTtopics"
-	     size="50"
-	     maxlength="250"
-	     name="SORTtopics"
-	     value="[% processed_params.SORTtopics | html %]" />
+             size="50"
+             maxlength="250"
+             name="SORTtopics"
+             value="[% processed_params.SORTtopics | html %]" />
     </p>
     [% END %]
 
@@ -111,19 +111,19 @@
     <p>
       <label for="date">[% loc('Date of the original publication') %]</label>
       <input class="form-control" id="date"
-	     size="50"
-	     maxlength="250"
-	     name="date"
-	     value="[% processed_params.date | html %]" />
+             size="50"
+             maxlength="250"
+             name="date"
+             value="[% processed_params.date | html %]" />
     </p>
-    
+
     <p><label for="source">[% loc('Source') %]</label>
 
       ([% loc('For texts from the internet use') %]:
        [% loc('Retrieved on DATE from URL') %]).
 
       <input class="form-control" id="source" size="50" maxlength="250"
-	         name="source" value="[% processed_params.source | html %]" />
+                 name="source" value="[% processed_params.source | html %]" />
     </p>
     [% END %]
     <p>
@@ -161,7 +161,7 @@
         from word” button. This is supposed to preserve the markup.') %]
 
         <br />
-        
+
         [% loc('This is a WYSIWYG editor. If you prefer to use
         the wiki-like syntax leave it as is, fill the required fields
         above and postpone the editing to the next step.') %]
@@ -192,7 +192,7 @@
         <input id="texthtmlfile" name="texthtmlfile" type="file" />
       </p>
     </div>
-    
+
     [% IF f_class == 'text' %]
     <h3>[% loc('Notes') %]</h3>
     <div>
@@ -271,7 +271,7 @@
         step, where you can also insert images.') %]
       </p>
       <button type="submit" class="btn btn-default"
-	          name="go" value="go">
+                  name="go" value="go">
         [% loc('Create') %]
       </button>
     </div>
@@ -330,12 +330,12 @@
             });
         }
 
-	    $( ".amwautocomplete")
-	        .bind( "keydown", function( event ) {
-		        if ( event.keyCode === $.ui.keyCode.TAB &&
-		             $( this ).data( "ui-autocomplete" ).menu.active ) {
-		            event.preventDefault();
-		        }
+            $( ".amwautocomplete")
+                .bind( "keydown", function( event ) {
+                        if ( event.keyCode === $.ui.keyCode.TAB &&
+                             $( this ).data( "ui-autocomplete" ).menu.active ) {
+                            event.preventDefault();
+                        }
                 var target = $(this).attr('name');
                 if (target === 'SORTauthors') {
                     availableTerms = all_terms.author;
@@ -350,25 +350,25 @@
                     console.log("Autocomplete not available for " + target);
                     availableTerms = [];
                 }
-	        })
-	        .autocomplete({
-		        minLength: 0,
-		        source: function( request, response ) {
-		            // delegate back to autocomplete, but extract the last term
-		            response( $.ui.autocomplete.filter(
-			            availableTerms, request.term.split(separator).pop()));
-		        },
-		        focus: function() {
-		            return false;
-		        },
-		        select: function( event, ui ) {
-		            var terms = this.value.split(separator);
-		            terms.pop();
-		            terms.push( ui.item.value );
-		            this.value = terms.join( ", " );
-		            return false;
-		        }
-	        });
+                })
+                .autocomplete({
+                        minLength: 0,
+                        source: function( request, response ) {
+                            // delegate back to autocomplete, but extract the last term
+                            response( $.ui.autocomplete.filter(
+                                    availableTerms, request.term.split(separator).pop()));
+                        },
+                        focus: function() {
+                            return false;
+                        },
+                        select: function( event, ui ) {
+                            var terms = this.value.split(separator);
+                            terms.pop();
+                            terms.push( ui.item.value );
+                            this.value = terms.join( ", " );
+                            return false;
+                        }
+                });
     });
 </script>
 

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -67,12 +67,14 @@
   </div>
 
   <div class="form-group">
-    <label for="SORTauthors">[% loc('Authors for indexing') %]</label>,
-    [% loc('comma or semicolon separated list') %]:
+    <label for="SORTauthors">[% loc('Authors for indexing') %]</label>
     <input class="form-control amwautocomplete" id="SORTauthors"
            maxlength="250"
            name="SORTauthors"
            value="[% processed_params.SORTauthors | html %]" />
+    <p class="help-block">
+      [% loc('Comma or semicolon separated list') %].
+    </p>
   </div>
 
   [% IF site.fixed_category_list %]
@@ -92,14 +94,15 @@
   </div>
   [% ELSE %]
   <div class="form-group">
-    <label for="SORTtopics">[% loc('Topics') %]</label>:
-    [% loc('comma or semicolon separated list') %]
-    <br />
+    <label for="SORTtopics">[% loc('Topics') %]</label>
     <input class="form-control amwautocomplete" id="SORTtopics"
            size="50"
            maxlength="250"
            name="SORTtopics"
            value="[% processed_params.SORTtopics | html %]" />
+    <p class="help-block">
+      [% loc('Comma or semicolon separated list') %].
+    </p>
   </div>
   [% END %]
 

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -23,8 +23,7 @@
   <div class="form-group">
     <label for="title" class="mandatory">[% loc('Title') %]
       ([% loc('mandatory') %])
-    </label>:
-    [% loc('if by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1') %]
+    </label>
     <a href="#choose-uri">
       <span class="fa fa-share"></span>
     </a>
@@ -32,6 +31,9 @@
            maxlength="250" id="title"
            size="30"
            value="[% processed_params.title | html %]" />
+    <p class="help-block">
+      [% loc('If by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1') %].
+    </p>
   </div>
 
   <div class="form-group">

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -37,7 +37,7 @@
   </div>
 
   <div class="form-group">
-    <label for="subtitle">[% loc('Subtitle') %]</label>:
+    <label for="subtitle">[% loc('Subtitle') %]</label>
     <input class="form-control" type="text" name="subtitle" id="subtitle"
            maxlength="250"
            size="30"

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -164,24 +164,25 @@
 
   <h3>[% loc('Main text') %]</h3>
   <div>
+    <p>
       [% loc('Please note that you may want to paste from a
         Word/OpenOffice/LibreOffice/HTML document using the “paste
         from word” button. This is supposed to preserve the markup.') %]
-
-      <br />
-
+    </p>
+    <p>
       [% loc('This is a WYSIWYG editor. If you prefer to use
         the wiki-like syntax leave it as is, fill the required fields
         above and postpone the editing to the next step.') %]
-      <br />
-
+    </p>
+    <p>
       [% loc('Image uploading may be done on the next step, when you can
         review and preview the upload.') %]
-
-      <br />
+    </p>
+    <p>
       [% loc('Keep in mind that unusually
         complex formatting will be stripped. Is it possible to add
         tables and images only on the next step.') %]
+    </p>
   </div>
   <div>&nbsp;</div>
   <div>

--- a/root/src/edit/newtext.tt
+++ b/root/src/edit/newtext.tt
@@ -24,15 +24,15 @@
     <label for="title" class="mandatory">[% loc('Title') %]
       ([% loc('mandatory') %])
     </label>
-    <a href="#choose-uri">
-      <span class="fa fa-share"></span>
-    </a>
     <input class="form-control" type="text" name="title"
            maxlength="250" id="title"
            size="30"
            value="[% processed_params.title | html %]" />
     <p class="help-block">
       [% loc('If by chance another text with the same author and title exists, choose the desired URI using the field below inserting author, title and a number, e.g. my-author-my-title-1') %].
+      <a href="#choose-uri">
+        <span class="fa fa-share"></span>
+      </a>
     </p>
   </div>
 


### PR DESCRIPTION
Already fixed bootstrap layout to avoid wrapping the whole form into single `div`.

Going to remove colons and periods from input labels, move help text to `<p class="help-block">` and make sure help text consists of complete sentences.