### PR TITLE
Format revision date as YYYY-MM-DD for sorting

### DIFF
--- a/root/src/edit/revs.tt
+++ b/root/src/edit/revs.tt
@@ -26,7 +26,7 @@
     </a>
     </td>
     <td>
-      [% rev.updated.dmy %] [% rev.updated.hms %] [% loc('UTC') %]
+      [% rev.updated.ymd %] [% rev.updated.hms %] [% loc('UTC') %]
     </td>
     <td>
     [% IF rev.editing_ongoing %]

--- a/root/src/publish/pending.tt
+++ b/root/src/publish/pending.tt
@@ -106,7 +106,7 @@
       </td>
       <td>
         [% # this is a bogus value created by HTML import %]
-        [% rev.updated.dmy %] [% rev.updated.hms %] [% loc('UTC') %]
+        [% rev.updated.ymd %] [% rev.updated.hms %] [% loc('UTC') %]
       </td>
     </tr>
     [% END %]


### PR DESCRIPTION
The javascript column sorting on revisions data tables is alphanumeric,
so DD-MM-YYYY dates are not usefully sorted. YYYY-MM-DD format fixes
this.