### PR TITLE
Avoid jumpy scroll in mobile Firefox related to navbar

### DIFF
--- a/root/src/layout.tt
+++ b/root/src/layout.tt
@@ -129,7 +129,7 @@
 
     [%# our css for the web application %]
     <link rel="stylesheet" type="text/css"
-          href="[% c.uri_for('/static/css/amusewiki.css', { v => 44 }) %]" />
+          href="[% c.uri_for('/static/css/amusewiki.css', { v => 45 }) %]" />
     <script src="[% c.uri_for('/static/js/amuse.js', { v => 6 }) %]"></script>
     <script>
       function amw_confirm() { return confirm('[% lh.loc('Are you sure?') | escape_js %]') }
@@ -797,7 +797,7 @@
       </div>
     </div>
     <script src="[% c.uri_for('/static/js/amw-autosuggest.js') %]"></script>
-    <script src="[% c.uri_for('/static/js/amw-navbar.js', { v => 2 }) %]"></script>
+    <script src="[% c.uri_for('/static/js/amw-navbar.js', { v => 3 }) %]"></script>
   </body>
 </html>
 

--- a/root/static/css/amusewiki.css
+++ b/root/static/css/amusewiki.css
@@ -57,6 +57,19 @@ div.float_image_r {
     padding: 0 0 0 19px;
 }
 
+.navbar {
+    border-radius: 0;
+    border-width: 0 0 1px;
+}
+
+body[style*="padding-top"] .navbar:not(.navbar-fixed-top) {
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 1030;
+}
+
 img.amw-navlogo-img {
     padding: 5px 5px;
     height: 50px;

--- a/root/static/js/amw-navbar.js
+++ b/root/static/js/amw-navbar.js
@@ -1,15 +1,27 @@
-/* the navbar is fixed only on scroll up */
+/*
+The navbar is fixed on scroll up.
+Static until JS loads. Otherwise absolute.
+But avoid changing between fixed and absolute when a menu is open.
+Related CSS: `body[style*="padding-top"] .navbar:not(.navbar-fixed-top)`.
+*/
 $(document).ready(function() {
     var previous = 0;
     var hash = window.location.hash || '';
-    $(window).scroll(function() {
-        var navbarheight = $('#amw-nav-bar-top').height();
-        var scroll = $(window).scrollTop();
+    var $window = $(window);
+    var $body = $(document.body);
+    var $navbar = $('#amw-nav-bar-top');
+    function updateNavbar() {
+        var scroll = $window.scrollTop();
         var newhash = window.location.hash || '';
-        if (hash === newhash && scroll > 0 && scroll < previous) {
+        var topMenuOpen = $navbar.find('.collapse.in');
+        var menuOpen =
+            topMenuOpen.length || $navbar.find('.dropdown.open').length;
+        var navbarHeightPlusMargin =
+            $navbar.outerHeight(true) - (topMenuOpen.height() || 0);
+        $body.css('padding-top', navbarHeightPlusMargin);
+        if (hash === newhash && scroll > 0 && scroll < previous && !menuOpen) {
             if ((previous - scroll) > 120) {
-                $('#amw-nav-bar-top').addClass('navbar-fixed-top');
-                $('body').css('margin-top', navbarheight);
+                $navbar.addClass('navbar-fixed-top');
                 previous = scroll;
             }
             /*
@@ -18,11 +30,12 @@ $(document).ready(function() {
             }
             */
         }
-        else {
-            $('#amw-nav-bar-top').removeClass('navbar-fixed-top');
-            $('body').css('margin-top', 0);
+        else if (!menuOpen) {
+            $navbar.removeClass('navbar-fixed-top');
             previous = scroll;
         }
         hash = newhash;
-    })
+    }
+    $window.scroll(updateNavbar);
+    updateNavbar();
 });


### PR DESCRIPTION
This adds workarounds for different kinds of unexpected scroll behavior in Firefox, GNOME Web and NetSurf.