### PR TITLE
Implement cleanup of mirror leftovers

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2038,6 +2038,7 @@ t/fail-on-cropmarks-109.t
 t/failed-thumbs.t
 t/failure-reason-371.t
 t/farsi.t
+t/federation-mirror-only.t
 t/federation.t
 t/files/amw-version-22.pdf
 t/files/big.jpeg

--- a/lib/AmuseWikiFarm/Schema/Result/Site.pm
+++ b/lib/AmuseWikiFarm/Schema/Result/Site.pm
@@ -3329,6 +3329,7 @@ sub update_from_params_restricted {
                         cgit_integration         => 'option',
                         allow_hostname_aliases   => 'option',
                         additional_nginx_conf    => 'option',
+                        mirror_only              => 'option',
 
                         vhosts            => 'delete',
 
@@ -3639,6 +3640,7 @@ sub update_from_params {
     foreach my $option (qw/html_special_page_bottom use_luatex
                            allow_hostname_aliases
                            additional_nginx_conf
+                           mirror_only
                            html_regular_page_bottom
                            left_layout_html
                            right_layout_html
@@ -5661,6 +5663,10 @@ sub has_aggregations {
 
 sub has_collections {
     shift->nodes->count;
+}
+
+sub mirror_only {
+    shift->get_option('mirror_only') ? 1 : 0;
 }
 
 after insert => sub {

--- a/lib/AmuseWikiFarm/Schema/ResultSet/Job.pm
+++ b/lib/AmuseWikiFarm/Schema/ResultSet/Job.pm
@@ -55,14 +55,15 @@ sub handled_jobs_hashref {
             rebuild => 20,
             reindex => 19,
             build_custom_format => 25, # after publish/rebuild/reindex but before the static indexes
-            build_static_indexes => 30,
             # testing
             testing => 10,
             testing_high => 5,
             download_remote => 26,
             install_downloaded => 27,
             prune_orphans => 28,
-            refresh_oai_pmh_repo => 29,
+            purge_mirror_leftovers => 29,
+            refresh_oai_pmh_repo => 90,
+            build_static_indexes => 100,
            };
 }
 

--- a/lib/AmuseWikiFarm/Schema/ResultSet/MirrorInfo.pm
+++ b/lib/AmuseWikiFarm/Schema/ResultSet/MirrorInfo.pm
@@ -32,6 +32,12 @@ sub with_exceptions {
     return $self->search({ "$me.mirror_exception" => { '!=' => '' } });
 }
 
+sub removed_upstream {
+    my $self = shift;
+    my $me = $self->current_source_alias;
+    return $self->search({ "$me.mirror_exception" => 'removed_upstream' });
+}
+
 sub without_origin {
     my $self = shift;
     my $me = $self->current_source_alias;

--- a/root/src/admin/edit.tt
+++ b/root/src/admin/edit.tt
@@ -93,6 +93,16 @@
       </div>
     </div>
     <div class="form-group">
+      <div class="col-sm-offset-3 col-sm-9">
+        <label>
+          <input type="checkbox"
+                 [% IF esite.mirror_only %]checked="checked"[% END %]
+                 name="mirror_only" />
+          [% loc('The site is a pure mirror (see the Federation page) and will not allow local files') %]
+        </label>
+      </div>
+    </div>
+    <div class="form-group">
         <div class="col-sm-offset-3 col-sm-9">
           <label>
             <input type="checkbox"

--- a/root/src/federation/show.tt
+++ b/root/src/federation/show.tt
@@ -115,6 +115,11 @@ https://amusewiki.org/category/topic/doc</pre>
 <div class="center">
   <div class="page-header">
     <h2>[% loc('Local pages') %]</h2>
+    [% IF site.mirror_only %]
+      <p>
+        [% loc('This site is a pure mirror and untracked pages will be removed automatically') %]
+      </p>
+    [% END %]
   </div>
 </div>
 

--- a/t/federation-mirror-only.t
+++ b/t/federation-mirror-only.t
@@ -1,0 +1,132 @@
+#!perl
+
+use utf8;
+use strict;
+use warnings;
+use Test::More tests => 26;
+BEGIN { $ENV{DBIX_CONFIG_DIR} = "t" };
+
+use File::Spec::Functions qw/catdir catfile/;
+use AmuseWikiFarm::Archive::BookBuilder;
+use lib catdir(qw/t lib/);
+
+use AmuseWiki::Tests qw/create_site/;
+use AmuseWikiFarm::Schema;
+use Test::WWW::Mechanize::Catalyst;
+use Data::Dumper::Concise;
+use Path::Tiny;
+
+my $schema = AmuseWikiFarm::Schema->connect('amuse');
+
+my $orig = create_site($schema, '0federation3');
+my $mirror = create_site($schema, '0federation4');
+my $mech_orig = Test::WWW::Mechanize::Catalyst->new(catalyst_app => 'AmuseWikiFarm',
+                                                    host => $orig->canonical);
+
+my $mech_mirror = Test::WWW::Mechanize::Catalyst->new(catalyst_app => 'AmuseWikiFarm',
+                                                      host => $mirror->canonical);
+
+$schema->resultset('Job')->delete;
+$schema->resultset('BulkJob')->delete;
+diag $mirror->repo_root;
+
+{
+    foreach my $title (qw/one two three/) {
+        my $muse = path($orig->repo_root, qw/t tt/, "to-test-$title.muse");
+        $muse->parent->mkpath;
+        $muse->spew_utf8(<<"MUSE");
+#authors Author $title; Authors $title; Pinco, Pallino
+#title Title $title
+#topics Topic $title
+#lang en
+#author My author $title
+
+Test $title
+MUSE
+    }
+    $orig->git->add('t');
+    $orig->git->commit({ message => "Added files" });
+    diag "Updating DB from tree";
+    $orig->update_db_from_tree;
+    is $orig->titles->count, 3;
+}
+
+{
+    my $local_muse = path($mirror->repo_root, qw/t tt/, "to-test-pizza.muse");
+    $local_muse->parent->mkpath;
+    $local_muse->spew_utf8(<<"MUSE");
+#title Local file
+#lang en
+
+Test
+
+MUSE
+    $mirror->git->add('t');
+    $mirror->git->commit({ message => "Added files" });
+    diag "Updating DB from tree";
+    $mirror->update_db_from_tree;
+    is $mirror->titles->count, 1;
+}
+
+$mirror->add_to_mirror_origins({
+                                remote_domain => $orig->canonical,
+                                remote_path => '/',
+                                active => 1,
+                               });
+my $remote = $mirror->mirror_origins->first;
+$remote->ua($mech_orig);
+_fetch_remote($remote);
+is $mirror->titles->count, 4, "Mirror OK";
+
+# now let's remove one remote
+
+{
+    path($orig->repo_root, qw/t tt to-test-one.muse/)->remove;
+    $orig->git->add('t');
+    $orig->git->commit({ message => "Removed files" });
+    diag "Updating DB from tree";
+    $orig->update_db_from_tree;
+    is $orig->titles->count, 2;
+}
+
+# and refetch
+
+_fetch_remote($remote);
+is $mirror->titles->count, 4, "Mirror OK";
+$mirror->jobs->enqueue('purge_mirror_leftovers', {});
+while (my $job = $mirror->jobs->dequeue) {
+    $job->dispatch_job;
+    is $job->status, 'completed';
+    diag $job->logs;
+}
+is $mirror->titles->count, 4, "Mirror intact";
+
+$mirror->site_options->update_or_create({
+                                         option_name => 'mirror_only',
+                                         option_value => 1
+                                        });
+
+for (1..2) {
+    $schema->resultset('Job')->enqueue_global_job('hourly_job');
+    while (my $job = $schema->resultset('Job')->dequeue) {
+        $job->dispatch_job;
+        is $job->status, 'completed';
+        diag $job->logs;
+    }
+    is $mirror->titles->count, 2, "Mirror purged because of the option";
+}
+
+sub _fetch_remote {
+    my ($remote) = @_;
+    my $res = $remote->fetch_remote;
+    diag Dumper($res);
+    ok $res->{data}, "Fetched remote";
+    ok !$res->{error}, "No errors";
+    my $bulk_job = $remote->prepare_download($res->{data});
+    my $site = $remote->site;
+    while (my $job = $site->jobs->dequeue) {
+        $job->dispatch_job({ ua => $remote->ua });        
+        is $job->status, 'completed';
+        diag $job->logs;
+    }
+}


### PR DESCRIPTION
Normally, when a site is using federation, does not remove the files which are removed upstream, but just list them as "Removed upstream" in the console.

Sites which are only doing a mirroring should purge such files automatically.

Added restricted option to do so.